### PR TITLE
deprecating kinetiq

### DIFF
--- a/adapters/kinetiq.ts
+++ b/adapters/kinetiq.ts
@@ -31,6 +31,6 @@ export default {
   total: (data: { points: number }) => ({ kPoints: data.points }),
   rank: (data: { rank?: number }) => data.rank || 0,
   deprecated: () => ({
-    points: 1760572800, // October 16th 2025 GMT
+    kPoints: 1760572800, // October 16th 2025 GMT
   }),
 } as AdapterExport;


### PR DESCRIPTION
- Kinetiq kpoints is now over
- https://x.com/kinetiq_xyz/status/1978108321405051178

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a deprecation marker to an adapter that exposes a static points value for lifecycle handling and signaling.
  * The marker provides a fixed computed points footprint but does not modify existing data, totals, rankings, or data mappings.
  * No user-visible behavior or data outcomes are changed by this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->