### PR TITLE
fixing adapters

### DIFF
--- a/adapters/resolv.ts
+++ b/adapters/resolv.ts
@@ -1,11 +1,16 @@
 import type { AdapterExport } from "../utils/adapter.ts";
+
 import { convertKeysToStartCase } from "../utils/object.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
 // NOTE: API for leaderboard
 // https://api.resolv.im/points/leaderboard?page=1
-const API_URL = "https://web-api.resolv.xyz/points?address={address}";
-const RANK_URL =
-  "https://web-api.resolv.xyz/points/leaderboard/slice?address={address}";
+const API_URL = await maybeWrapCORSProxy(
+  "https://web-api.resolv.xyz/points?address={address}"
+);
+const RANK_URL = await maybeWrapCORSProxy(
+  "https://web-api.resolv.xyz/points/leaderboard/slice?address={address}"
+);
 
 /*
 {


### PR DESCRIPTION
- This PR is for fixing broken adapters.
- Resolv has been updated to the new api for points.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Switched backend endpoints to a more reliable web API, improving data fetch stability and responsiveness.
* **Chores**
  * Minor internal cleanup and formatting tweaks; no changes to public APIs or visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update Resolv adapter to use new web-api endpoints for points and leaderboard slice.
> 
> - **Adapters**:
>   - **Resolv**:
>     - Update `API_URL` to `https://web-api.resolv.xyz/points?address={address}`.
>     - Update `RANK_URL` to `https://web-api.resolv.xyz/points/leaderboard/slice?address={address}`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1759dda81e3abc6985c0916eaa1a3b8b22044be. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->