### PR TITLE
fix jumper

### DIFF
--- a/adapters/jumperexchange.ts
+++ b/adapters/jumperexchange.ts
@@ -10,12 +10,18 @@ const LEADERBOARD_URL = await maybeWrapCORSProxy(
 
 export default {
   fetch: async (address: string) => {
+    const headers = {
+      Referer: "https://jumper.exchange/",
+    };
     const [rewards, leaderboard] = await Promise.all([
-      (await fetch(API_URL.replace("{address}", address))).json(),
-      (await fetch(LEADERBOARD_URL.replace("{address}", address))).json(),
+      await fetch(API_URL.replace("{address}", address), { headers }),
+      await fetch(LEADERBOARD_URL.replace("{address}", address), { headers }),
     ]);
 
-    return { rewards, leaderboard };
+    return {
+      rewards: await rewards.json(),
+      leaderboard: await leaderboard.json(),
+    };
   },
   data: ({
     rewards,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a Referer header to Jumper API requests and parses responses after fetch to ensure rewards/leaderboard retrieval.
> 
> - **Adapters**:
>   - **`adapters/jumperexchange.ts`**:
>     - Add `Referer: https://jumper.exchange/` header to `fetch` requests for `rewards` and `leaderboard` endpoints.
>     - Refactor fetch logic to await responses first and call `.json()` after, returning parsed `{ rewards, leaderboard }`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6be9a5ef65262c5c03292dbb3e66e77f09b279c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal handling of API requests and response processing for improved efficiency and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->