### PR TITLE
Adding nansen adapter

### DIFF
--- a/adapters/nansen.ts
+++ b/adapters/nansen.ts
@@ -1,6 +1,7 @@
 import { getAddress } from "viem";
 import { AdapterExport } from "../utils/adapter.ts";
 import { maybeWrapCORSProxy } from "../utils/cors.ts";
+import { convertKeysToStartCase } from "../utils/object.ts";
 
 const API_URL = await maybeWrapCORSProxy(
   "https://app.nansen.ai/api/points-leaderboard",
@@ -22,12 +23,12 @@ export default {
     is_eligible: boolean;
   }) => {
     if (!data) return {};
-    return {
+    return convertKeysToStartCase({
       points: data.points,
       rank: data.rank,
       tier: data.tier,
-      is_eligible: String(data.is_eligible),
-    };
+      is_eligible: data.is_eligible ? "Yes" : "No",
+    });
   },
   total: (data: { points: number }) => {
     if (!data) return 0;


### PR DESCRIPTION
- Added new nansen adapter
- Testing Address: 0x6E93Ebc8302890fF1D1BeFd779D1DB131eF30D4d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Nansen leaderboard adapter: fetches leaderboard entries from Nansen, matches by address, and exposes normalized points, rank, tier, and eligibility.
  * Handles missing data gracefully (returns empty data or zero for totals/rank) and uses a CORS-wrapped API endpoint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->