### PR TITLE
update jumper referrer

### DIFF
--- a/adapters/jumperexchange.ts
+++ b/adapters/jumperexchange.ts
@@ -11,7 +11,7 @@ const LEADERBOARD_URL = await maybeWrapCORSProxy(
 export default {
   fetch: async (address: string) => {
     const headers = {
-      Referer: "https://jumper.exchange/",
+      Referer: "https://checkpoint.exchange/",
     };
     const [rewards, leaderboard] = await Promise.all([
       await fetch(API_URL.replace("{address}", address), { headers }),


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Switches the Referer header in `adapters/jumperexchange.ts` from `https://jumper.exchange/` to `https://checkpoint.exchange/` for API requests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79bf1ce8056f7bd6cf40dc5366cf81dd94a602c0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated configuration settings for external service integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->