### PR TITLE
Add GitHub Action for Adapter Testing

### DIFF
--- a/.github/workflows/adapter-test.yaml
+++ b/.github/workflows/adapter-test.yaml
@@ -55,13 +55,13 @@ jobs:
                 
                 # Second parameter is optional file
                 if [ -n "$PARAM2" ]; then
-                  # Validate file format (must be file.ts)
-                  if echo "$PARAM2" | grep -qE '^.+\.ts$'; then
+                  # Validate file format (must be file.ts with no path traversal)
+                  if echo "$PARAM2" | grep -qE '^[^/\\]+\.ts$'; then
                     # Convert filename to adapters/filename.ts
                     CUSTOM_FILE="adapters/$PARAM2"
                     echo "Using custom file: $CUSTOM_FILE"
                   else
-                    echo "Invalid file format: $PARAM2 (must be file.ts)"
+                    echo "Invalid file format: $PARAM2 (must be filename.ts without path separators)"
                     exit 1
                   fi
                 fi
@@ -70,7 +70,6 @@ jobs:
                 exit 1
               fi
             else
-              # Skip if the comment is not a /test command
               echo "Regular comment (not /test command), skipping"
               exit 0
             fi
@@ -78,14 +77,31 @@ jobs:
             # PR event - try to parse address from PR template
             if [ -n "$PR_BODY" ]; then
               echo "Parsing PR template for test address..."
-              # Look for address in "Test Address (with points):" section
-              PR_ADDRESS=$(echo "$PR_BODY" | sed -n '/Test Address (with points):/,/```/p' | sed -n '1,/```/p' | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+              echo "PR Body preview:"
+              echo "$PR_BODY" | head -20
               
-              if [ -n "$PR_ADDRESS" ]; then
-                ADDRESS="$PR_ADDRESS"
-                echo "Found address in PR template: $ADDRESS"
+              # Look for address in "**Test Address (with points):**" section
+              ADDRESS_SECTION=$(echo "$PR_BODY" | sed -n '/\*\*Test Address (with points):\*\*/,/```.*```/p')
+              
+              if [ -n "$ADDRESS_SECTION" ]; then
+                echo "Found address section:"
+                echo "$ADDRESS_SECTION"
+                
+                # Extract content between backticks (inside the code block)
+                CODE_BLOCK_CONTENT=$(echo "$ADDRESS_SECTION" | sed -n '/```/,/```/p' | sed '1d;$d')
+                echo "Code block content: '$CODE_BLOCK_CONTENT'"
+                
+                # Extract 0x address from the code block content, ignoring placeholder text
+                PR_ADDRESS=$(echo "$CODE_BLOCK_CONTENT" | grep -oE '0x[a-fA-F0-9]{40}' | head -n1)
+                
+                if [ -n "$PR_ADDRESS" ] && [ "$PR_ADDRESS" != "0x..." ]; then
+                  ADDRESS="$PR_ADDRESS"
+                  echo "Found valid address in PR template: $ADDRESS"
+                else
+                  echo "No valid address found in PR template (found placeholder or empty), using default"
+                fi
               else
-                echo "No address found in PR template, using default"
+                echo "Test Address section not found in PR template, using default"
               fi
             else
               echo "No PR body available, using default address"
@@ -134,6 +150,8 @@ jobs:
               CHANGED_FILES=$(git diff --name-only origin/main | grep "^adapters/.*\.ts$" || true)
               if [ -z "$CHANGED_FILES" ]; then
                 echo "No adapter files found to test. Skipping tests."
+                # Set empty output before exiting
+                echo "changed_files=" >> $GITHUB_OUTPUT
                 exit 0
               fi
             fi
@@ -142,6 +160,8 @@ jobs:
             CHANGED_FILES=$(git diff --name-only origin/main..HEAD | grep "^adapters/.*\.ts$" || true)
             if [ -z "$CHANGED_FILES" ]; then
               echo "No adapter files found to test. Skipping tests."
+              # Set empty output before exiting
+              echo "changed_files=" >> $GITHUB_OUTPUT
               exit 0
             fi
           fi
@@ -207,7 +227,7 @@ jobs:
               echo "\`\`\`" >> test_output.txt
               
               # Capture both stdout and stderr
-              custom_test_output=$(deno run -A test.ts "$CHANGED_FILE" "$POINTS_ADDRESS" 2>&1 || true)
+              custom_test_output=$(deno run --allow-net --allow-read=adapters --allow-env test.ts "$CHANGED_FILE" "$POINTS_ADDRESS" 2>&1 || true)
               
               echo "$custom_test_output" >> test_output.txt
               echo "\`\`\`" >> test_output.txt
@@ -222,7 +242,7 @@ jobs:
               echo "\`\`\`" >> test_output.txt
               
               # Capture both stdout and stderr
-              test1_output=$(deno run -A test.ts "$CHANGED_FILE" "$POINTS_ADDRESS" 2>&1 || true)
+              test1_output=$(deno run --allow-net --allow-read=adapters --allow-env test.ts "$CHANGED_FILE" "$POINTS_ADDRESS" 2>&1 || true)
               
               echo "$test1_output" >> test_output.txt
               echo "\`\`\`" >> test_output.txt
@@ -237,7 +257,7 @@ jobs:
               echo "\`\`\`" >> test_output.txt
               
               # Capture both stdout and stderr
-              test2_output=$(deno run -A test.ts "$CHANGED_FILE" "$NO_POINTS_ADDRESS" 2>&1 || true)
+              test2_output=$(deno run --allow-net --allow-read=adapters --allow-env test.ts "$CHANGED_FILE" "$NO_POINTS_ADDRESS" 2>&1 || true)
               
               echo "$test2_output" >> test_output.txt
               echo "\`\`\`" >> test_output.txt


### PR DESCRIPTION
Introduce a GitHub Action that runs adapter tests on pull requests, allowing users to specify test addresses via comments. The action validates addresses, runs tests on changed adapter files, and comments the results back to the PR.
## Example outputs

### Multiple adapter change
<img width="847" height="343" alt="Screenshot 2025-11-15 at 22 34 59" src="https://github.com/user-attachments/assets/cb1d6862-4e38-46ba-99ba-550c6bd5ad84" />

### Single adapter change
<img width="840" height="265" alt="Screenshot 2025-11-15 at 22 35 35" src="https://github.com/user-attachments/assets/c91be9f3-89a6-48d2-99f2-dc8e9e343c8f" />

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated CI workflow ("Adapter Test") to run adapter tests on pull requests and via PR comments using a /test command. It detects changed adapters, accepts an optional custom file/address, runs tests per adapter (including a zero-address case), aggregates outputs, posts a summarized PR comment with results and retest instructions, validates input, masks sensitive data, and tolerates non‑critical failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a GitHub Actions workflow to run Deno-based adapter tests on PRs or via `/test` comments and post summarized results back to the PR.
> 
> - **CI/GitHub Actions**:
>   - **New workflow**: `/.github/workflows/adapter-test.yaml` triggers on PRs to `main` (limited to `adapters/*.ts`) and on `/test` issue comments.
>   - **Change detection**: Diffs against `origin/main` to find changed `adapters/*.ts`, or uses a custom file from `/test`.
>   - **Parameter parsing**: Extracts test address from PR body or `/test <address> [file.ts]` (validates `.ts`), with a default fallback.
>   - **Deno setup**: Installs Deno v2, caches dependencies, runs `deno run -A test.ts <file> <address>` per changed adapter.
>   - **Test matrix**: On PRs, runs both a likely-points address and a sentinel no-points address; on `/test`, runs only the provided address.
>   - **Reporting**: Aggregates outputs into `test_output.txt` and comments results to the PR (with collapsible sections); posts an immediate status comment for `/test` and deletes it after posting results.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit df631e7c676494e8d8bd2a5db46f5c776b153bbc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->