### PR TITLE
fix kinetiq

### DIFF
--- a/test.ts
+++ b/test.ts
@@ -96,7 +96,7 @@ if (res.rank) console.log(`User Rank: ${nth(res.rank)}`);
 if (res.claimable) console.log(`Is there an airdrop? ${res.claimable}`);
 
 if (res.deprecated && Object.keys(res.deprecated).length > 0) {
-  const labels = Object.keys(res.data);
+  const labels = Object.keys(res.total);
 
   const invalidKeys = Object.keys(res.deprecated).filter(
     (key) => !labels.includes(key) && key != "Points"


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update Kinetiq adapter to use the new POST-based kpoints API with checksum normalization and line-delimited response parsing; adjust test to validate deprecated keys against total.
> 
> - **Adapters**
>   - **`adapters/kinetiq.ts`**:
>     - Switch endpoint to `https://kinetiq.xyz/kpoints` (via `maybeWrapCORSProxy`).
>     - Use `POST` with body `{ chainId: 1, userAddress }` and `next-action` header.
>     - Normalize `address` using `viem` `checksumAddress`.
>     - Parse newline-delimited response; extract line containing `address` and `JSON.parse` after removing prefix.
> - **Tests**
>   - **`test.ts`**: Validate deprecated keys against `res.total` instead of `res.data`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bd78e7f000d54702f188bc604db68f3ec8e3db3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced data output to include Rank information alongside existing Tier data, providing more comprehensive insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->