### PR TITLE
fix: Add breakdown data to prjx adapter

### DIFF
--- a/adapters/prjx.ts
+++ b/adapters/prjx.ts
@@ -19,7 +19,13 @@ export default {
 
     return data;
   },
-  data: (_) => ({}),
+  data: (data: API_RESPONSE) => {
+    if (!data) return {};
+    return {
+      "Total Points": data.pointsTotal,
+      "Rank": data.rank,
+    };
+  },
   total: (data: API_RESPONSE) => data.pointsTotal,
   rank: (data: API_RESPONSE) => data.rank,
 } as AdapterExport;


### PR DESCRIPTION
- Return Total Points and Rank in breakdown
- Fixes breakdown table display on ProtocolPage
- Maintains total and rank functions for header display

## IMPORTANT NOTES

### Before Submitting:
- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address and an invalid address
- [ ] Ensure your adapter works with different address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**
```
0x...
```

**Expected Output:**
- Total Points: 
- Rank: 

**How to Test Locally:**
```bash
deno run --allow-net --allow-read=adapters test.ts adapters/your-adapter.ts <address>
```

---

## Adapter Details

**Protocol Name:**


**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**
- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:**
(Any additional context for this PR)
