### PR TITLE
Adding galxe protocol adapter

### DIFF
--- a/adapters/galxe.ts
+++ b/adapters/galxe.ts
@@ -65,20 +65,14 @@ export default {
     return {
       XP: {
         Username: data.addressInfo.username,
-        Experience: data.addressInfo.userLevel.exp,
+        XP: data.addressInfo.userLevel.exp,
         Level: level,
         // really weird thing where accounts that dont exist return 81991 for gold when it is actually 0
         Gold: gold === 81991 && level === 1 ? 0 : gold,
       },
     };
   },
-  total: (data: API_RESPONSE) => {
-    const gold = data.addressInfo.userLevel.gold;
-    const level = data.addressInfo.userLevel.level.value;
-    return {
-      XP: data.addressInfo.userLevel.exp,
-      Level: level,
-      Gold: gold === 81991 && level === 1 ? 0 : gold,
-    };
-  },
+  total: (data: API_RESPONSE) => ({
+    XP: data.addressInfo.userLevel.exp,
+  }),
 } as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:
- [x] Enable "Allow edits by maintainers" on this PR
- [x] Test your adapter locally with a valid address and an invalid address
- [x] Ensure your adapter works with different address formats (checksummed, lowercase, uppercase)
- [x] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [x] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/galxe.ts`

**Test Address (with points):**
```
0x69155e7ca2e688ccdc247f6c4ddf374b3ae77bd6
```

**Expected Output:**
- Total Points: 4030
- Rank: 21

**How to Test Locally:**
```bash
deno run --allow-net --allow-read=adapters test.ts adapters/your-adapter.ts <address>
```

---

## Adapter Details

**Protocol Name:**


**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols)) gravity-by-galxe

**Important Features:**
- [x] Supports multiple address formats (lowercase, uppercase, checksummed)
- [x] CORS-friendly API calls
- [x] Fails fast on errors
- [x] Adapter result is 100% truth

---

**Notes:**
(Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Galxe integration to retrieve and display username, level, experience (XP) and gold.
  * Displays aggregated XP/Gold totals in the platform.

* **Bug Fixes**
  * Applies a special-case correction: anomalous gold value (81991) for level‑1 accounts is treated as 0.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->