### PR TITLE
Fix adapters

### DIFF
--- a/adapters/doma.ts
+++ b/adapters/doma.ts
@@ -17,9 +17,9 @@ export default {
       },
       body: JSON.stringify({
         query:
-          "query LeaderboardByAddress($walletAddress: AddressCAIP10!) {\n  leaderboard(walletAddress: $walletAddress) {\n    liquidAmountUsd\n    liquidityProvidedUsd\n    stakingAmountUsd\n    points\n    rank\n    totalDomains\n    totalSubdomains\n    tradingVolumeUsd\n    walletAddress\n  }\n}",
+          "query LeaderboardByAddress($walletAddress: AddressCAIP10!, $weekNumber: Int, $season: LeaderboardSeason, $scope: LeaderboardScope) {  leaderboard(    walletAddress: $walletAddress    weekNumber: $weekNumber    season: $season    scope: $scope  ) {    points    rank    referralCount    referralPoints    referralBonusLimit    referralBonusesAwarded    tradingVolumeUsd    walletAddress    totalEntries    weekNumber    currentLevelThreshold    level    nextLevel    userMultiplier    nextThreshold    pointsMultiplier    closingDomaLevel    bonusPointsAwarded    seasonPoints    pointsByType {      TRADING      REFERRAL      QUEST      LEVEL_UP_BONUS      WEEKLY_REWARD      SNAPSHOT    }  }}",
         variables: {
-          walletAddress: `eip155:1:${getAddress(address)}`,
+          walletAddress: `eip155:_:${getAddress(address)}`,
         },
       }),
     });
@@ -33,5 +33,6 @@ export default {
     data.leaderboard.points,
   rank: (data: { leaderboard: Record<string, number | string> }) =>
     data.leaderboard.rank,
+  // TODO: The API supports SVM but cant find any SVM addresses in their leaderboard.
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/inflynce.ts
+++ b/adapters/inflynce.ts
@@ -1,33 +1,14 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { getFidFromCustodyAddress } from "../utils/farcaster.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
-import { getAddress } from "viem";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://miniapp.inflynce.com/api/graphql"
-);
-
+// Inflynce has shut down on April 9th.
+// ref: https://farcaster.xyz/inflynce/0x3844263a
 export default {
-  fetch: async (address) => {
-    const res = await fetch(API_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-      },
-      body: JSON.stringify({
-        operationName: "GetPointsByFid",
-        query:
-          "query GetPointsByFid($fid: String!) {user_points_by_pk(fid: $fid) {fid totalPoints} }",
-        variables: { fid: await getFidFromCustodyAddress(getAddress(address)) },
-      }),
-    });
-    const data = (await res.json()).data.user_points_by_pk;
-    return data ?? { totalPoints: 0 };
-  },
-  data: (data: { totalPoints: number }) => ({
-    IP: data.totalPoints,
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
+  total: () => 0,
+  claimable: () => false,
+  deprecated: () => ({
+    Points: 1775692800, // April 19th 2026
   }),
-  total: (data: { totalPoints: number }) => ({ IP: data.totalPoints }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/inflynce.ts
+++ b/adapters/inflynce.ts
@@ -8,7 +8,8 @@ export default {
   total: () => 0,
   claimable: () => false,
   deprecated: () => ({
-    Points: 1775692800, // April 19th 2026
+    Points: 1775692800, // April 9th 2026
+  }),
   }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/nansen.ts
+++ b/adapters/nansen.ts
@@ -1,52 +1,31 @@
 import { AdapterExport } from "../utils/adapter.ts";
 import { maybeWrapCORSProxy } from "../utils/cors.ts";
 import { convertKeysToStartCase } from "../utils/object.ts";
-import { requireAddressType } from "../utils/address.ts";
 
 const API_URL = await maybeWrapCORSProxy(
-  "https://app.nansen.ai/api/points-leaderboard"
+  "https://app.nansen.ai/api/points-leaderboard/{address}"
 );
 
 // 0x6E93Ebc8302890fF1D1BeFd779D1DB131eF30D4d - Testing address
+// { tier: "star", points: 1540069 }
 export default {
   fetch: async (address: string) => {
-    const res = await fetch(API_URL, {
+    const res = await fetch(API_URL.replace("{address}", address), {
       headers: { "User-Agent": "Checkpoint API (https://checkpoint.exchange)" },
     });
-    const data = await res.json();
 
-    const addressType = requireAddressType(address);
-    const target = addressType === "evm" ? address.toLowerCase() : address;
-
-    return (
-      data.find((obj: { evm_address?: string; solana_address?: string }) =>
-        addressType === "svm"
-          ? obj?.solana_address === target
-          : obj?.evm_address?.toLowerCase() === target
-      ) ?? null
-    );
+    return await res.json();
   },
-  data: (data: {
-    points: number;
-    rank: number;
-    tier: string;
-    is_eligible: boolean;
-  }) => {
+  data: (data: { points: number; tier: string }) => {
     if (!data) return {};
     return convertKeysToStartCase({
       points: data.points,
-      rank: data.rank,
       tier: data.tier,
-      is_eligible: data.is_eligible ? "Yes" : "No",
     });
   },
   total: (data: { points: number }) => {
     if (!data) return 0;
     return data.points;
-  },
-  rank: (data: { rank: number }) => {
-    if (!data) return 0;
-    return data.rank;
   },
   supportedAddressTypes: ["evm", "svm"],
 } as AdapterExport;

--- a/adapters/taiko.ts
+++ b/adapters/taiko.ts
@@ -5,7 +5,7 @@ export default {
   fetch: async () => await Promise.resolve({}),
   data: () => ({}),
   total: () => 0,
-  claimable: () => true,
+  claimable: () => false,
   deprecated: () => ({
     Points: 1765756800, // Dec 15th 2025
   }),

--- a/adapters/taiko.ts
+++ b/adapters/taiko.ts
@@ -4,10 +4,10 @@ import type { AdapterExport } from "../utils/adapter.ts";
 export default {
   fetch: async () => await Promise.resolve({}),
   data: () => ({}),
-  total: ({ totalScore }: Record<string, number>) => totalScore,
-  rank: ({ rank }: Record<string, number>) => rank,
+  total: () => 0,
+  claimable: () => true,
   deprecated: () => ({
-    Points: 1765756800,
+    Points: 1765756800, // Dec 15th 2025
   }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/taiko.ts
+++ b/adapters/taiko.ts
@@ -1,75 +1,13 @@
 import type { AdapterExport } from "../utils/adapter.ts";
-import { convertKeysToStartCase } from "../utils/object.ts";
-import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
-const API_URL = await maybeWrapCORSProxy(
-  "https://trailblazer.mainnet.taiko.xyz/s4/user/rank?address={address}"
-);
-
-/*
-{
-  rank: 3,
-  address: "0x1602E644d80036EE566E7893BCE6009FE63dB47a",
-  score: 7640957.241653256,
-  multiplier: 1,
-  totalScore: 7640957.241653256,
-  total: 411820,
-  blacklisted: false,
-  breakdown: [
-    { event: "Transaction", total_points: 12347489.875 },
-    { event: "TransactionValue", total_points: 12346348.375 },
-    { event: "FrozenBonus", total_points: 7032.24336 },
-  ],
-}
-*/
+// S6, the final season, ended on Dec 15th.
 export default {
-  fetch: async (address: string) => {
-    return await (
-      await fetch(API_URL.replace("{address}", address), {
-        headers: {
-          "User-Agent":
-            "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36 Checkpoint API (https://checkpoint.exchange)",
-        },
-      })
-    ).json();
-  },
-  data: ({
-    multiplier = 1,
-    totalScore = 0,
-    breakdown = [],
-    total = 0,
-    score = 0,
-    rank = 0,
-  }: Record<string, number | Array<Record<string, string | number>>>) => {
-    const getPoints = (event: string) =>
-      Array.isArray(breakdown)
-        ? Number(breakdown.find((x) => x.event === event)?.total_points || 0)
-        : 0;
-
-    const events = Array.isArray(breakdown)
-      ? breakdown.reduce(
-          (
-            acc: Record<string, number>,
-            item: Record<string, string | number>
-          ) => {
-            const event = item.event as string;
-            acc[`${event} Points`] = getPoints(event);
-            return acc;
-          },
-          {} as Record<string, number>
-        )
-      : {};
-
-    return convertKeysToStartCase({
-      multiplier,
-      totalScore,
-      score,
-      total,
-      rank,
-      ...events,
-    });
-  },
+  fetch: async () => await Promise.resolve({}),
+  data: () => ({}),
   total: ({ totalScore }: Record<string, number>) => totalScore,
   rank: ({ rank }: Record<string, number>) => rank,
+  deprecated: () => ({
+    Points: 1765756800,
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [x] Enable "Allow edits by maintainers" on this PR
- [x] Test your adapter locally with a valid address (EVM or SVM) and an invalid address
- [x] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [x] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [x] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
0x... or SVM base58...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Updates**
  * Enhanced Doma leaderboard with broader query support, additional filtering, and expanded leaderboard data.
  * Simplified Nansen points adapter and streamlined address handling and returned data.

* **Deprecations**
  * Inflynce points integration removed and replaced with a stubbed/deprecated response.
  * Taiko S6 rank integration removed and replaced with a stubbed/deprecated response.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->