### PR TITLE
Add Liquid, Ostium, and MegaETH adapters

### DIFF
--- a/adapters/liquid.ts
+++ b/adapters/liquid.ts
@@ -1,0 +1,62 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const USER_STATS_URL = await maybeWrapCORSProxy(
+  "https://api.liquidmax.xyz/api/data/user_stats?wallet_address={address}"
+);
+
+const RANK_URL = await maybeWrapCORSProxy(
+  "https://api.liquidmax.xyz/api/leaderboard/v2/check-rank?wallet={address}&metric=pnl&duration=all_time"
+);
+
+type USER_STATS_RESPONSE = {
+  total_points: number;
+  total_volume: number;
+  directional_bias: {
+    long_percentage: number;
+    short_percentage: number;
+  } | null;
+  trading_streak: {
+    current_streak: number;
+  } | null;
+};
+
+type RANK_RESPONSE = {
+  rank: number | null;
+};
+
+type API_RESPONSE = {
+  userStats: USER_STATS_RESPONSE;
+  rank: RANK_RESPONSE;
+};
+
+export default {
+  fetch: async (address) => {
+    const checksumAddress = getAddress(address);
+    const headers = {
+      headers: { "User-Agent": "Checkpoint API (https://checkpoint.exchange)" },
+    };
+
+    const [userStats, rank] = await Promise.all([
+      fetch(USER_STATS_URL.replace("{address}", checksumAddress), headers),
+      fetch(RANK_URL.replace("{address}", checksumAddress), headers),
+    ]);
+
+    return {
+      userStats: await userStats.json(),
+      rank: await rank.json(),
+    };
+  },
+  data: (data: API_RESPONSE) => ({
+    Points: data.userStats.total_points,
+    Rank: data.rank.rank ?? 0,
+    Volume: data.userStats.total_volume,
+    "Current Streak": data.userStats.trading_streak?.current_streak ?? 0,
+    Long: data.userStats.directional_bias?.long_percentage ?? 0,
+    Short: data.userStats.directional_bias?.short_percentage ?? 0,
+  }),
+  total: (data: API_RESPONSE) => data.userStats.total_points,
+  rank: (data: API_RESPONSE) => data.rank.rank ?? 0,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/liquid.ts
+++ b/adapters/liquid.ts
@@ -31,21 +31,37 @@ type API_RESPONSE = {
   rank: RANK_RESPONSE;
 };
 
+const headers = {
+  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+};
+
 export default {
   fetch: async (address) => {
     const checksumAddress = getAddress(address);
-    const headers = {
-      headers: { "User-Agent": "Checkpoint API (https://checkpoint.exchange)" },
-    };
+
+    const [userStatsResponse, rankResponse] = await Promise.all([
+      fetch(USER_STATS_URL.replace("{address}", checksumAddress), { headers }),
+      fetch(RANK_URL.replace("{address}", checksumAddress), { headers }),
+    ]);
+
+    if (!userStatsResponse.ok) {
+      throw new Error(
+        `liquid user stats api error: ${userStatsResponse.statusText}`
+      );
+    }
+
+    if (!rankResponse.ok) {
+      throw new Error(`liquid rank api error: ${rankResponse.statusText}`);
+    }
 
     const [userStats, rank] = await Promise.all([
-      fetch(USER_STATS_URL.replace("{address}", checksumAddress), headers),
-      fetch(RANK_URL.replace("{address}", checksumAddress), headers),
+      userStatsResponse.json() as Promise<USER_STATS_RESPONSE>,
+      rankResponse.json() as Promise<RANK_RESPONSE>,
     ]);
 
     return {
-      userStats: await userStats.json(),
-      rank: await rank.json(),
+      userStats,
+      rank,
     };
   },
   data: (data: API_RESPONSE) => ({
@@ -53,8 +69,12 @@ export default {
     Rank: data.rank.rank ?? 0,
     Volume: data.userStats.total_volume,
     "Current Streak": data.userStats.trading_streak?.current_streak ?? 0,
-    Long: data.userStats.directional_bias?.long_percentage ?? 0,
-    Short: data.userStats.directional_bias?.short_percentage ?? 0,
+    "Long Directional Bias": `${
+      data.userStats.directional_bias?.long_percentage ?? 0
+    }%`,
+    "Short Directional Bias": `${
+      data.userStats.directional_bias?.short_percentage ?? 0
+    }%`,
   }),
   total: (data: API_RESPONSE) => data.userStats.total_points,
   rank: (data: API_RESPONSE) => data.rank.rank ?? 0,

--- a/adapters/megaeth.ts
+++ b/adapters/megaeth.ts
@@ -29,42 +29,37 @@ type API_RESPONSE = {
   allTime?: LeaderboardEntry;
 };
 
-const emptyResponse = (address: string): API_RESPONSE => ({
-  address,
-});
-
 const parseLeaderboardEntries = (html: string): LeaderboardEntries => {
   const unescaped = html.replace(/\\"/g, '"').replace(/\\n/g, " ");
   const match = unescaped.match(
     /"entries":\{"weekly":(\[.*?\]),"all":(\[.*?\])\}/s
   );
 
-  if (!match) {
-    return { weekly: [], all: [] };
-  }
+  if (!match) throw new Error("failed to parse megaeth leaderboard data");
 
-  return JSON.parse(`{"weekly":${match[1]},"all":${match[2]}}`) as LeaderboardEntries;
+  return JSON.parse(
+    `{"weekly":${match[1]},"all":${match[2]}}`
+  ) as LeaderboardEntries;
 };
 
-const findEntry = (entries: LeaderboardEntry[], address: string) =>
+const findEntry = (entries: LeaderboardEntry[], lowerCaseAddress: string) =>
   entries.find(
-    (entry) => entry.mainWalletAddress.toLowerCase() === address.toLowerCase()
+    (entry) => entry.mainWalletAddress.toLowerCase() === lowerCaseAddress
   );
 
 export default {
   fetch: async (address) => {
     const res = await fetch(LEADERBOARD_URL, { headers });
 
-    if (!res.ok) {
-      return emptyResponse(address);
-    }
+    if (!res.ok) throw new Error("megaeth api error: " + res.statusText);
 
+    const lowerCaseAddress = address.toLowerCase();
     const entries = parseLeaderboardEntries(await res.text());
 
     return {
       address,
-      weekly: findEntry(entries.weekly, address),
-      allTime: findEntry(entries.all, address),
+      weekly: findEntry(entries.weekly, lowerCaseAddress),
+      allTime: findEntry(entries.all, lowerCaseAddress),
     };
   },
   data: (data: API_RESPONSE) => ({

--- a/adapters/megaeth.ts
+++ b/adapters/megaeth.ts
@@ -1,0 +1,80 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const LEADERBOARD_URL = await maybeWrapCORSProxy(
+  "https://terminal.megaeth.com/leaderboard"
+);
+
+const headers = {
+  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+  Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+};
+
+type LeaderboardEntry = {
+  rank: number;
+  xAccount?: string;
+  mainWalletAddress: string;
+  totalPoints: number;
+  weeklyPointsChange: number;
+};
+
+type LeaderboardEntries = {
+  weekly: LeaderboardEntry[];
+  all: LeaderboardEntry[];
+};
+
+type API_RESPONSE = {
+  address: string;
+  weekly?: LeaderboardEntry;
+  allTime?: LeaderboardEntry;
+};
+
+const emptyResponse = (address: string): API_RESPONSE => ({
+  address,
+});
+
+const parseLeaderboardEntries = (html: string): LeaderboardEntries => {
+  const unescaped = html.replace(/\\"/g, '"').replace(/\\n/g, " ");
+  const match = unescaped.match(
+    /"entries":\{"weekly":(\[.*?\]),"all":(\[.*?\])\}/s
+  );
+
+  if (!match) {
+    return { weekly: [], all: [] };
+  }
+
+  return JSON.parse(`{"weekly":${match[1]},"all":${match[2]}}`) as LeaderboardEntries;
+};
+
+const findEntry = (entries: LeaderboardEntry[], address: string) =>
+  entries.find(
+    (entry) => entry.mainWalletAddress.toLowerCase() === address.toLowerCase()
+  );
+
+export default {
+  fetch: async (address) => {
+    const res = await fetch(LEADERBOARD_URL, { headers });
+
+    if (!res.ok) {
+      return emptyResponse(address);
+    }
+
+    const entries = parseLeaderboardEntries(await res.text());
+
+    return {
+      address,
+      weekly: findEntry(entries.weekly, address),
+      allTime: findEntry(entries.all, address),
+    };
+  },
+  data: (data: API_RESPONSE) => ({
+    "Total Points": data.allTime?.totalPoints ?? data.weekly?.totalPoints ?? 0,
+    Rank: data.allTime?.rank ?? 0,
+    "Weekly Points": data.weekly?.weeklyPointsChange ?? 0,
+    "Weekly Rank": data.weekly?.rank ?? 0,
+  }),
+  total: (data: API_RESPONSE) =>
+    data.allTime?.totalPoints ?? data.weekly?.totalPoints ?? 0,
+  rank: (data: API_RESPONSE) => data.allTime?.rank ?? 0,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/ostium.ts
+++ b/adapters/ostium.ts
@@ -1,0 +1,204 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const USER_POINTS_URL = await maybeWrapCORSProxy(
+  "https://onlypoints.ostium.io/api/points/user/{address}"
+);
+
+const SEASONS_URL = await maybeWrapCORSProxy(
+  "https://onlypoints.ostium.io/api/seasons"
+);
+
+const headers = {
+  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+};
+
+type Season = {
+  id: string;
+  name: string;
+  status: "active" | "completed" | "upcoming" | string;
+  seasonGroup: number;
+  startTime: number;
+  endTime: number;
+};
+
+type SeasonPoint = {
+  seasonId: string;
+  points: number;
+  rank: number;
+  breakdown?: {
+    trading?: number;
+    lp?: number;
+  };
+};
+
+type UserPointsResponse = {
+  userId: string;
+  totalPoints: number;
+  preSeasonPoints: number;
+  bountyPoints: number;
+  rank: number;
+  seasonPoints: SeasonPoint[];
+};
+
+type API_RESPONSE = {
+  user: UserPointsResponse;
+  seasons: Season[];
+};
+
+const emptyUser = (address: string): UserPointsResponse => ({
+  userId: address,
+  totalPoints: 0,
+  preSeasonPoints: 0,
+  bountyPoints: 0,
+  rank: 0,
+  seasonPoints: [],
+});
+
+const fetchJson = async <T>(url: string, fallback: T): Promise<T> => {
+  const res = await fetch(url, { headers });
+  if (!res.ok) return fallback;
+  return (await res.json()) as T;
+};
+
+const seasonById = (seasons: Season[]) =>
+  new Map(seasons.map((season) => [season.id, season]));
+
+const seasonGroupLabel = (season?: Season) =>
+  season ? `Season ${season.seasonGroup}` : "Unknown Season";
+
+const totalBySeasonGroup = (data: API_RESPONSE) => {
+  const seasons = seasonById(data.seasons);
+  const totals: Record<string, number> = {};
+
+  for (const seasonPoint of data.user.seasonPoints ?? []) {
+    const season = seasons.get(seasonPoint.seasonId);
+    if (!season) continue;
+
+    const key = `${seasonGroupLabel(season)} Points`;
+    totals[key] = (totals[key] ?? 0) + seasonPoint.points;
+  }
+
+  if (data.user.preSeasonPoints > 0) {
+    totals["Preseason Points"] = data.user.preSeasonPoints;
+  }
+
+  if (data.user.bountyPoints > 0) {
+    totals["Bounty Points"] = data.user.bountyPoints;
+  }
+
+  return totals;
+};
+
+const unmappedSeasonPoints = (data: API_RESPONSE) => {
+  const seasons = seasonById(data.seasons);
+
+  return (data.user.seasonPoints ?? []).reduce((sum, seasonPoint) => {
+    return seasons.has(seasonPoint.seasonId) ? sum : sum + seasonPoint.points;
+  }, 0);
+};
+
+const seasonGroups = (data: API_RESPONSE): Record<string, Record<string, number>> => {
+  const seasons = seasonById(data.seasons);
+  const grouped: Record<string, Record<string, number>> = {};
+
+  for (const seasonPoint of data.user.seasonPoints ?? []) {
+    const season = seasons.get(seasonPoint.seasonId);
+    if (!season) continue;
+
+    const seasonLabel = seasonGroupLabel(season);
+    const weekLabel = season.name;
+
+    grouped[seasonLabel] ??= {};
+    grouped[seasonLabel][weekLabel] =
+      (grouped[seasonLabel][weekLabel] ?? 0) + seasonPoint.points;
+  }
+
+  return Object.fromEntries(
+    Object.entries(grouped)
+      .sort(([a], [b]) => {
+        const aSeason = Number(a.match(/\d+/)?.[0] ?? 0);
+        const bSeason = Number(b.match(/\d+/)?.[0] ?? 0);
+        return bSeason - aSeason;
+      })
+      .map(([seasonLabel, weeks]) => {
+        const sortedWeeks = Object.fromEntries(
+          Object.entries(weeks).sort(([a], [b]) => {
+            const aWeek = Number(a.match(/\d+/)?.[0] ?? 0);
+            const bWeek = Number(b.match(/\d+/)?.[0] ?? 0);
+            return aWeek - bWeek;
+          })
+        );
+
+        return [
+          seasonLabel,
+          {
+            "Total Points": Object.values(weeks).reduce(
+              (sum, points) => sum + points,
+              0
+            ),
+            ...sortedWeeks,
+          },
+        ];
+      })
+  );
+};
+
+export default {
+  fetch: async (address) => {
+    const lowerCaseAddress = address.toLowerCase();
+
+    const [user, seasons] = await Promise.all([
+      fetchJson<UserPointsResponse>(
+        USER_POINTS_URL.replace("{address}", lowerCaseAddress),
+        emptyUser(lowerCaseAddress)
+      ),
+      fetchJson<Season[]>(SEASONS_URL, []),
+    ]);
+
+    return { user, seasons };
+  },
+  data: (data: API_RESPONSE) => {
+    const output: Record<string, Record<string, number>> = seasonGroups(data);
+
+    if (
+      data.user.totalPoints > 0 ||
+      data.user.preSeasonPoints > 0 ||
+      data.user.bountyPoints > 0 ||
+      unmappedSeasonPoints(data) > 0
+    ) {
+      output["Summary"] = {
+        "Total Points": data.user.totalPoints,
+        Rank: data.user.rank,
+        "Preseason Points": data.user.preSeasonPoints,
+        "Bounty Points": data.user.bountyPoints,
+        "Unmapped Season Points": unmappedSeasonPoints(data),
+      };
+    }
+
+    return output;
+  },
+  total: (data: API_RESPONSE) => {
+    const totals = totalBySeasonGroup(data);
+    return Object.keys(totals).length > 0 ? totals : data.user.totalPoints;
+  },
+  rank: (data: API_RESPONSE) => data.user.rank,
+  deprecated: (data: Partial<API_RESPONSE>) => {
+    const seasons = Array.isArray(data.seasons) ? data.seasons : [];
+    const activeSeason = seasons.find((season) => season.status === "active");
+    const currentSeasonGroup =
+      activeSeason?.seasonGroup ??
+      Math.max(0, ...seasons.map((season) => season.seasonGroup));
+
+    const deprecatedGroups = seasons.filter(
+      (season) => season.seasonGroup < currentSeasonGroup
+    );
+
+    return deprecatedGroups.reduce<Record<string, number>>((acc, season) => {
+      const key = `Season ${season.seasonGroup} Points`;
+      acc[key] = Math.max(acc[key] ?? 0, season.endTime);
+      return acc;
+    }, {});
+  },
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/ostium.ts
+++ b/adapters/ostium.ts
@@ -41,9 +41,19 @@ type UserPointsResponse = {
   seasonPoints: SeasonPoint[];
 };
 
-type API_RESPONSE = {
+type RawAPIResponse = {
   user: UserPointsResponse;
   seasons: Season[];
+};
+
+type SeasonData = {
+  grouped: Record<string, Record<string, number>>;
+  totals: Record<string, number>;
+  unmappedPoints: number;
+};
+
+type API_RESPONSE = RawAPIResponse & {
+  seasonData: SeasonData;
 };
 
 const emptyUser = (address: string): UserPointsResponse => ({
@@ -55,28 +65,60 @@ const emptyUser = (address: string): UserPointsResponse => ({
   seasonPoints: [],
 });
 
-const fetchJson = async <T>(url: string, fallback: T): Promise<T> => {
-  const res = await fetch(url, { headers });
-  if (!res.ok) return fallback;
-  return (await res.json()) as T;
+const seasonPointsKey = (seasonGroup: number) => `Season ${seasonGroup} Points`;
+
+const deprecatedBySeasonGroup = (seasons: Season[]) => {
+  const activeSeason = seasons.find((season) => season.status === "active");
+  let currentSeasonGroup = activeSeason?.seasonGroup ?? 0;
+
+  if (!activeSeason) {
+    for (const season of seasons) {
+      if (season.seasonGroup > currentSeasonGroup) {
+        currentSeasonGroup = season.seasonGroup;
+      }
+    }
+  }
+
+  const deprecated: Record<string, number> = {};
+
+  for (const season of seasons) {
+    if (season.seasonGroup >= currentSeasonGroup) continue;
+
+    const key = seasonPointsKey(season.seasonGroup);
+    deprecated[key] = Math.max(deprecated[key] ?? 0, season.endTime);
+  }
+
+  return deprecated;
 };
 
-const seasonById = (seasons: Season[]) =>
-  new Map(seasons.map((season) => [season.id, season]));
-
-const seasonGroupLabel = (season?: Season) =>
-  season ? `Season ${season.seasonGroup}` : "Unknown Season";
-
-const totalBySeasonGroup = (data: API_RESPONSE) => {
-  const seasons = seasonById(data.seasons);
+const buildSeasonData = (data: RawAPIResponse): SeasonData => {
+  const seasons = new Map<string, Season>();
+  const grouped: Record<string, Record<string, number>> = {};
   const totals: Record<string, number> = {};
+  let unmappedPoints = 0;
+
+  for (const season of data.seasons) {
+    seasons.set(season.id, season);
+
+    const key = seasonPointsKey(season.seasonGroup);
+    grouped[key] ??= { "Total Points": 0 };
+    totals[key] ??= 0;
+  }
 
   for (const seasonPoint of data.user.seasonPoints ?? []) {
     const season = seasons.get(seasonPoint.seasonId);
-    if (!season) continue;
+    if (!season) {
+      unmappedPoints += seasonPoint.points;
+      continue;
+    }
 
-    const key = `${seasonGroupLabel(season)} Points`;
+    const key = seasonPointsKey(season.seasonGroup);
+
     totals[key] = (totals[key] ?? 0) + seasonPoint.points;
+    grouped[key] ??= { "Total Points": 0 };
+    grouped[key]["Total Points"] += seasonPoint.points;
+    grouped[key][season.name] =
+      (grouped[key][season.name] ?? 0) + seasonPoint.points;
   }
 
   if (data.user.preSeasonPoints > 0) {
@@ -87,118 +129,71 @@ const totalBySeasonGroup = (data: API_RESPONSE) => {
     totals["Bounty Points"] = data.user.bountyPoints;
   }
 
-  return totals;
-};
-
-const unmappedSeasonPoints = (data: API_RESPONSE) => {
-  const seasons = seasonById(data.seasons);
-
-  return (data.user.seasonPoints ?? []).reduce((sum, seasonPoint) => {
-    return seasons.has(seasonPoint.seasonId) ? sum : sum + seasonPoint.points;
-  }, 0);
-};
-
-const seasonGroups = (data: API_RESPONSE): Record<string, Record<string, number>> => {
-  const seasons = seasonById(data.seasons);
-  const grouped: Record<string, Record<string, number>> = {};
-
-  for (const seasonPoint of data.user.seasonPoints ?? []) {
-    const season = seasons.get(seasonPoint.seasonId);
-    if (!season) continue;
-
-    const seasonLabel = seasonGroupLabel(season);
-    const weekLabel = season.name;
-
-    grouped[seasonLabel] ??= {};
-    grouped[seasonLabel][weekLabel] =
-      (grouped[seasonLabel][weekLabel] ?? 0) + seasonPoint.points;
-  }
-
-  return Object.fromEntries(
-    Object.entries(grouped)
-      .sort(([a], [b]) => {
-        const aSeason = Number(a.match(/\d+/)?.[0] ?? 0);
-        const bSeason = Number(b.match(/\d+/)?.[0] ?? 0);
-        return bSeason - aSeason;
-      })
-      .map(([seasonLabel, weeks]) => {
-        const sortedWeeks = Object.fromEntries(
-          Object.entries(weeks).sort(([a], [b]) => {
-            const aWeek = Number(a.match(/\d+/)?.[0] ?? 0);
-            const bWeek = Number(b.match(/\d+/)?.[0] ?? 0);
-            return aWeek - bWeek;
-          })
-        );
-
-        return [
-          seasonLabel,
-          {
-            "Total Points": Object.values(weeks).reduce(
-              (sum, points) => sum + points,
-              0
-            ),
-            ...sortedWeeks,
-          },
-        ];
-      })
-  );
+  return { grouped, totals, unmappedPoints };
 };
 
 export default {
   fetch: async (address) => {
-    const lowerCaseAddress = address.toLowerCase();
+    address = address.toLowerCase();
 
-    const [user, seasons] = await Promise.all([
-      fetchJson<UserPointsResponse>(
-        USER_POINTS_URL.replace("{address}", lowerCaseAddress),
-        emptyUser(lowerCaseAddress)
-      ),
-      fetchJson<Season[]>(SEASONS_URL, []),
+    const [userResponse, seasonsResponse] = await Promise.all([
+      fetch(USER_POINTS_URL.replace("{address}", address), {
+        headers,
+      }),
+      fetch(SEASONS_URL, { headers }),
     ]);
 
-    return { user, seasons };
+    if (!userResponse.ok && userResponse.status !== 404) {
+      throw new Error(
+        `Ostium user points request failed with status ${userResponse.status}`
+      );
+    }
+
+    if (!seasonsResponse.ok) {
+      throw new Error(
+        `Ostium seasons request failed with status ${seasonsResponse.status}`
+      );
+    }
+
+    const [user, seasons] = await Promise.all([
+      userResponse.status === 404
+        ? emptyUser(address)
+        : (userResponse.json() as Promise<UserPointsResponse>),
+      seasonsResponse.json() as Promise<Season[]>,
+    ]);
+
+    return { user, seasons, seasonData: buildSeasonData({ user, seasons }) };
   },
   data: (data: API_RESPONSE) => {
-    const output: Record<string, Record<string, number>> = seasonGroups(data);
+    const output: Record<string, Record<string, number>> = data.seasonData
+      .grouped;
+
+    for (const key of Object.keys(deprecatedBySeasonGroup(data.seasons))) {
+      output[key] ??= { "Total Points": 0 };
+    }
 
     if (
       data.user.totalPoints > 0 ||
       data.user.preSeasonPoints > 0 ||
       data.user.bountyPoints > 0 ||
-      unmappedSeasonPoints(data) > 0
+      data.seasonData.unmappedPoints > 0
     ) {
       output["Summary"] = {
         "Total Points": data.user.totalPoints,
         Rank: data.user.rank,
         "Preseason Points": data.user.preSeasonPoints,
         "Bounty Points": data.user.bountyPoints,
-        "Unmapped Season Points": unmappedSeasonPoints(data),
+        "Unmapped Season Points": data.seasonData.unmappedPoints,
       };
     }
 
     return output;
   },
   total: (data: API_RESPONSE) => {
-    const totals = totalBySeasonGroup(data);
+    const totals = data.seasonData.totals;
     return Object.keys(totals).length > 0 ? totals : data.user.totalPoints;
   },
   rank: (data: API_RESPONSE) => data.user.rank,
-  deprecated: (data: Partial<API_RESPONSE>) => {
-    const seasons = Array.isArray(data.seasons) ? data.seasons : [];
-    const activeSeason = seasons.find((season) => season.status === "active");
-    const currentSeasonGroup =
-      activeSeason?.seasonGroup ??
-      Math.max(0, ...seasons.map((season) => season.seasonGroup));
-
-    const deprecatedGroups = seasons.filter(
-      (season) => season.seasonGroup < currentSeasonGroup
-    );
-
-    return deprecatedGroups.reduce<Record<string, number>>((acc, season) => {
-      const key = `Season ${season.seasonGroup} Points`;
-      acc[key] = Math.max(acc[key] ?? 0, season.endTime);
-      return acc;
-    }, {});
-  },
+  deprecated: (data: API_RESPONSE) => deprecatedBySeasonGroup(data.seasons),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;


### PR DESCRIPTION
## Summary
- Add points adapters for Liquid, Ostium, and MegaETH.
- Fetch protocol-specific leaderboard/points data and expose totals, ranks, and useful breakdown fields.

## Test plan
- Not run; this submodule does not define a test script.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for Liquid user stats and leaderboard rank with normalized metrics (points, rank, volume, streak, bias)
  * MegaETH leaderboard integration showing weekly and all-time points and ranks
  * Ostium points and season tracking with grouped season summaries, totals, rank, and unmapped-season handling
<!-- end of auto-generated comment: release notes by coderabbit.ai -->