### PR TITLE
Add IntegraLayer adapter

### DIFF
--- a/adapters/integralayer.ts
+++ b/adapters/integralayer.ts
@@ -1,0 +1,51 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://dashboard-apis.integralayer.com/api/v1/xp/{address}"
+);
+
+const headers = {
+  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+};
+
+type API_RESPONSE = {
+  wallet: string;
+  xp: number;
+  rank: number | null;
+  breakdown: {
+    staking_xp: number;
+    social_xp: number;
+    game_xp: number;
+  };
+  last_updated: string;
+};
+
+export default {
+  fetch: async (address) => {
+    const res = await fetch(
+      API_URL.replace("{address}", address.toLowerCase()),
+      { headers }
+    );
+
+    if (!res.ok) {
+      throw new Error(`IntegraLayer XP API error: ${res.statusText}`);
+    }
+
+    return (await res.json()) as API_RESPONSE;
+  },
+  data: (data: API_RESPONSE) => ({
+    XP: {
+      "Total XP": data.xp,
+      "Social XP": data.breakdown.social_xp,
+      "Staking XP": data.breakdown.staking_xp,
+      "Gaming XP": data.breakdown.game_xp,
+      Rank: data.rank ?? 0,
+    },
+  }),
+  total: (data: API_RESPONSE) => ({
+    XP: data.xp,
+  }),
+  rank: (data: API_RESPONSE) => data.rank ?? 0,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;


### PR DESCRIPTION
## Summary
- Add an IntegraLayer XP adapter using the public wallet XP endpoint.
- Expose total XP, social/staking/gaming XP breakdown, and rank under the existing adapter contract.

## Test plan
- Verified the public IntegraLayer XP endpoint returns wallet XP data.
- Not run: Deno adapter harness, because `deno` is unavailable in the local environment.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integration with Integralayer to retrieve XP data and rankings for EVM addresses.
  * Provides detailed XP breakdown by category: Total, Social, Staking, and Gaming.
  * Displays rank alongside XP metrics, with normalized handling when rank is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->