### PR TITLE
Add IntegraLayer and new protocol adapters

### DIFF
--- a/adapters/altura.ts
+++ b/adapters/altura.ts
@@ -1,0 +1,98 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://app.altura.trade/api/leaderboard/search?address={address}&epoch={epoch}"
+);
+
+const ACTIVE_EPOCH = 4;
+
+type LeaderboardEntry = {
+  user_address?: string;
+  points?: number;
+  quest_points?: number;
+  rank?: number;
+  error?: string;
+};
+
+type API_RESPONSE = {
+  season4: LeaderboardEntry;
+};
+
+const emptyEntry = (address: string): LeaderboardEntry => ({
+  user_address: address,
+  points: 0,
+  quest_points: 0,
+  rank: 0,
+});
+
+const getSeason = (entry: LeaderboardEntry): Record<string, number> => {
+  return {
+    Points: Number(entry.points ?? 0),
+    "Quest Points": Number(entry.quest_points ?? 0),
+    Rank: Number(entry.rank ?? 0),
+  };
+};
+
+const fetchEpoch = async (
+  address: string,
+  epoch: number
+): Promise<LeaderboardEntry> => {
+  const res = await fetch(
+    API_URL.replace("{address}", address).replace("{epoch}", String(epoch)),
+    {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    }
+  );
+
+  if (res.status === 404) {
+    return emptyEntry(address);
+  }
+
+  if (!res.ok) {
+    throw new Error(`Altura leaderboard request failed with status ${res.status}`);
+  }
+
+  const data = await res.json() as LeaderboardEntry & {
+    twitterusername?: string | null;
+    twitterpfp?: string | null;
+  };
+
+  return {
+    user_address: data.user_address,
+    points: data.points,
+    quest_points: data.quest_points,
+    rank: data.rank,
+  };
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    return {
+      season4: await fetchEpoch(normalizedAddress, ACTIVE_EPOCH),
+    };
+  },
+  data: (response: API_RESPONSE) => {
+    return {
+      "Season 1": getSeason(emptyEntry(response.season4.user_address ?? "")),
+      "Season 2": getSeason(emptyEntry(response.season4.user_address ?? "")),
+      "Season 3": getSeason(emptyEntry(response.season4.user_address ?? "")),
+      "Season 4": getSeason(response.season4),
+    };
+  },
+  total: (response: API_RESPONSE) => ({
+    "Season 4": Number(response.season4.points ?? 0),
+  }),
+  rank: (response: API_RESPONSE) => Number(response.season4.rank ?? 0),
+  deprecated: () => ({
+    "Season 1": 1771545600, // Friday 20th February 2026 00:00 UTC
+    "Season 2": 1775174400, // Friday 3rd April 2026 00:00 UTC
+    "Season 3": 1777766400, // Sunday 3rd May 2026 00:00 UTC
+  }),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/altura.ts
+++ b/adapters/altura.ts
@@ -29,7 +29,7 @@ const emptyEntry = (address: string): LeaderboardEntry => ({
 
 const getSeason = (entry: LeaderboardEntry): Record<string, number> => {
   return {
-    Points: Number(entry.points ?? 0),
+    Peaks: Number(entry.points ?? 0),
     "Quest Points": Number(entry.quest_points ?? 0),
     Rank: Number(entry.rank ?? 0),
   };

--- a/adapters/apyx.ts
+++ b/adapters/apyx.ts
@@ -1,0 +1,66 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://api.apyx.fi/v1/point?address={address}"
+);
+
+type Conversion = {
+  conversionName: string;
+  total: string;
+};
+
+type API_RESPONSE = {
+  data?: {
+    address?: string;
+    points?: {
+      total?: string;
+      referralTotal?: string;
+      byConversion?: Conversion[];
+    };
+  };
+};
+
+const toNumber = (value: string | number | undefined): number =>
+  Number(value ?? 0) || 0;
+
+const getPoints = (data: API_RESPONSE) => data.data?.points ?? {};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`APYX point request failed with status ${res.status}`);
+    }
+
+    return await res.json();
+  },
+  data: (data: API_RESPONSE) => {
+    const points = getPoints(data);
+    const conversions = Object.fromEntries(
+      (points.byConversion ?? []).map((conversion) => [
+        conversion.conversionName,
+        toNumber(conversion.total),
+      ])
+    );
+
+    return {
+      Pips: {
+        Total: toNumber(points.total),
+        "Referral Pips": toNumber(points.referralTotal),
+        ...conversions,
+      },
+    };
+  },
+  total: (data: API_RESPONSE) => ({
+    Pips: toNumber(getPoints(data).total),
+  }),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/avant.ts
+++ b/adapters/avant.ts
@@ -1,0 +1,65 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://app.avantprotocol.com/api/rewards/merkl/{address}"
+);
+
+type CampaignBreakdown = {
+  campaignId?: string;
+  campaignName?: string;
+  amount?: string;
+};
+
+type API_RESPONSE = {
+  currentAmount?: string;
+  dailyIntake?: string;
+  dailyIntakeSelf?: string;
+  dailyIntakeReferral?: string;
+  campaignBreakdown?: CampaignBreakdown[];
+};
+
+const toNumber = (value: string | number | undefined): number =>
+  Number(value ?? 0) || 0;
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Avant rewards request failed with status ${res.status}`);
+    }
+
+    return await res.json();
+  },
+  data: (data: API_RESPONSE) => {
+    const campaigns = Object.fromEntries(
+      (data.campaignBreakdown ?? []).map((campaign) => [
+        campaign.campaignName ?? campaign.campaignId ?? "Unknown Campaign",
+        toNumber(campaign.amount),
+      ])
+    );
+
+    return {
+      Points: {
+        Total: toNumber(data.currentAmount),
+        "Daily Intake": toNumber(data.dailyIntake),
+        "Daily Intake Self": toNumber(data.dailyIntakeSelf),
+        "Daily Intake Referral": toNumber(data.dailyIntakeReferral),
+        // Avant's Galxe endpoint only powers fixed social quest eligibility.
+        // The ranked points ledger and leaderboard totals match this Merkl total.
+        ...campaigns,
+      },
+    };
+  },
+  total: (data: API_RESPONSE) => ({
+    Points: toNumber(data.currentAmount),
+  }),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/integralayer.ts
+++ b/adapters/integralayer.ts
@@ -1,0 +1,51 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://dashboard-apis.integralayer.com/api/v1/xp/{address}"
+);
+
+const headers = {
+  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+};
+
+type API_RESPONSE = {
+  wallet: string;
+  xp: number;
+  rank: number | null;
+  breakdown: {
+    staking_xp: number;
+    social_xp: number;
+    game_xp: number;
+  };
+  last_updated: string;
+};
+
+export default {
+  fetch: async (address) => {
+    const res = await fetch(
+      API_URL.replace("{address}", address.toLowerCase()),
+      { headers }
+    );
+
+    if (!res.ok) {
+      throw new Error(`IntegraLayer XP API error: ${res.statusText}`);
+    }
+
+    return (await res.json()) as API_RESPONSE;
+  },
+  data: (data: API_RESPONSE) => ({
+    XP: {
+      "Total XP": data.xp,
+      "Social XP": data.breakdown.social_xp,
+      "Staking XP": data.breakdown.staking_xp,
+      "Gaming XP": data.breakdown.game_xp,
+      Rank: data.rank ?? 0,
+    },
+  }),
+  total: (data: API_RESPONSE) => ({
+    XP: data.xp,
+  }),
+  rank: (data: API_RESPONSE) => data.rank ?? 0,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/mainstreet.ts
+++ b/adapters/mainstreet.ts
@@ -1,0 +1,83 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://api.mainstreet.finance/points/my-data?wallet={address}&season=3"
+);
+
+type API_RESPONSE = {
+  success?: boolean;
+  data?: {
+    totalPoints?: number;
+    claimedPoints?: number;
+    season1Points?: number;
+    season2Points?: number;
+    season3Points?: number;
+    season4Points?: number;
+    rank?: number;
+    season1Rank?: number;
+    season2Rank?: number;
+    season3Rank?: number;
+    season4Rank?: number;
+    updatedAt?: number;
+  };
+};
+
+type SeasonData = {
+  Points: number;
+  Rank: number;
+};
+
+const getData = (response: API_RESPONSE) => response.data ?? {};
+
+const getSeason = (
+  response: API_RESPONSE,
+  season: 1 | 2 | 3 | 4
+): SeasonData => {
+  const data = getData(response);
+
+  return {
+    Points: Number(data[`season${season}Points`] ?? 0),
+    Rank: Number(data[`season${season}Rank`] ?? 0),
+  };
+};
+
+export default {
+  fetch: async (address: string) => {
+    const res = await fetch(API_URL.replace("{address}", getAddress(address)), {
+      headers: {
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Mainstreet points request failed with status ${res.status}`);
+    }
+
+    return await res.json();
+  },
+  data: (response: API_RESPONSE) => {
+    const data = getData(response);
+
+    return {
+      "Season 1": getSeason(response, 1),
+      "Season 2": getSeason(response, 2),
+      "Season 3": getSeason(response, 3),
+      Totals: {
+        "Active Season Points": Number(data.season3Points ?? 0),
+        "All Seasons Points": Number(data.totalPoints ?? 0),
+        "Claimed Points": Number(data.claimedPoints ?? 0),
+      },
+    };
+  },
+  total: (response: API_RESPONSE) => ({
+    Gammas: Number(getData(response).season3Points ?? 0),
+  }),
+  rank: (response: API_RESPONSE) => Number(getData(response).season3Rank ?? 0),
+  deprecated: () => ({
+    "Season 1": 1762353092, // Wednesday 5th November 2025 14:31 UTC
+    "Season 2": 1777334400, // Tuesday 28th April 2026 00:00 UTC
+  }),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/pear.ts
+++ b/adapters/pear.ts
@@ -1,0 +1,160 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_BASE_URL = await maybeWrapCORSProxy("https://api.fuul.xyz/api/v1");
+
+const SEASONS = [
+  {
+    key: "Hypear Season 1 Points",
+    bearer: "474dbca7dd9bbea87574955416713c5436b295369b65d6bded6d682b9a60ca7d",
+    deprecatedAt: Date.UTC(2025, 9, 22) / 1000,
+  },
+  {
+    key: "Hypear Season 2 Points",
+    bearer: "9bcf04c003c32f6a2dc660e4ba1b6830c21d260ed6b856418d3b2a302cde41b9",
+    deprecatedAt: Date.UTC(2026, 2, 26) / 1000,
+  },
+  {
+    key: "Hypear Season 3 Points",
+    bearer: "ee672fb6b16ec804803dd3b8078e28e7da140127a00c166dbc8e391cf258accb",
+    deprecatedAt: undefined,
+  },
+] as const;
+
+type SeasonKey = (typeof SEASONS)[number]["key"];
+
+type LeaderboardEntry = {
+  address?: string;
+  user_identifier?: string;
+  user_identifier_type?: string;
+  total_amount?: number | string;
+  affiliate_name?: string | null;
+  rank?: number;
+  total_attributions?: number;
+};
+
+type LeaderboardResponse = {
+  results?: LeaderboardEntry[];
+  total_results?: number;
+  calculated_at?: string;
+};
+
+type SeasonResponse = {
+  leaderboard: LeaderboardEntry;
+  leaderboardTotal: number;
+  calculatedAt?: string;
+};
+
+type API_RESPONSE = Record<SeasonKey, SeasonResponse>;
+
+const emptyLeaderboard = (): LeaderboardEntry => ({
+  total_amount: 0,
+  rank: 0,
+  total_attributions: 0,
+});
+
+const headersFor = (bearer: string) => ({
+  accept: "application/json",
+  authorization: `Bearer ${bearer}`,
+  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+});
+
+const toNumber = (value: number | string | undefined): number => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (!value) return 0;
+  return Number(value) || 0;
+};
+
+const fetchJson = async <T>(path: string, bearer: string): Promise<T> => {
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    headers: headersFor(bearer),
+  });
+
+  if (res.status === 404) {
+    return { results: [], total_results: 0 } as T;
+  }
+
+  if (!res.ok) {
+    throw new Error(`Pear request failed with status ${res.status}`);
+  }
+
+  return await res.json() as T;
+};
+
+const fetchSeason = async (
+  address: string,
+  bearer: string
+): Promise<SeasonResponse> => {
+  const params = new URLSearchParams({
+    user_identifier: address,
+    user_identifier_type: "evm_address",
+  });
+
+  const leaderboard = await fetchJson<LeaderboardResponse>(
+    `/payouts/leaderboard/points?${params}`,
+    bearer
+  );
+
+  return {
+    leaderboard: leaderboard.results?.[0] ?? emptyLeaderboard(),
+    leaderboardTotal: Number(leaderboard.total_results ?? 0),
+    calculatedAt: leaderboard.calculated_at,
+  };
+};
+
+const getSeasonTotal = (season: SeasonResponse): number =>
+  toNumber(season.leaderboard.total_amount);
+
+const getLatestSeason = (response: API_RESPONSE): SeasonResponse => {
+  for (const season of [...SEASONS].reverse()) {
+    const seasonResponse = response[season.key];
+    if (getSeasonTotal(seasonResponse) > 0) {
+      return seasonResponse;
+    }
+  }
+  return response["Hypear Season 3 Points"];
+};
+
+const buildSeasonBreakdown = (season: SeasonResponse) => ({
+  "Total Points": getSeasonTotal(season),
+  Rank: Number(season.leaderboard.rank ?? 0),
+  "Total Attributions": Number(season.leaderboard.total_attributions ?? 0),
+});
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const entries = await Promise.all(
+      SEASONS.map(async (season) => [
+        season.key,
+        await fetchSeason(normalizedAddress, season.bearer),
+      ])
+    );
+
+    return Object.fromEntries(entries) as API_RESPONSE;
+  },
+  data: (response: API_RESPONSE) =>
+    Object.fromEntries(
+      SEASONS.map((season) => [
+        season.key,
+        buildSeasonBreakdown(response[season.key]),
+      ])
+    ),
+  total: (response: API_RESPONSE) =>
+    Object.fromEntries(
+      SEASONS.map((season) => [
+        season.key,
+        getSeasonTotal(response[season.key]),
+      ])
+    ),
+  rank: (response: API_RESPONSE) =>
+    Number(getLatestSeason(response).leaderboard.rank ?? 0),
+  deprecated: () =>
+    Object.fromEntries(
+      SEASONS.flatMap((season) =>
+        season.deprecatedAt ? [[season.key, season.deprecatedAt]] : []
+      )
+    ),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/sierra.ts
+++ b/adapters/sierra.ts
@@ -55,11 +55,6 @@ export default {
       }
     );
 
-    const contentType = res.headers.get("content-type") ?? "";
-    if (!contentType.includes("application/json")) {
-      throw new Error("Sierra PEAKS endpoint returned a non-JSON response");
-    }
-
     return await res.json();
   },
   data: (data: API_RESPONSE) => {

--- a/adapters/sierra.ts
+++ b/adapters/sierra.ts
@@ -71,7 +71,7 @@ export default {
     }
 
     return {
-      PEAKS: {
+      Peaks: {
         Total: entry.newBalance ?? 0,
         "Previous Balance": entry.previousBalance ?? 0,
         "This Week": entry.pointsThisWeek ?? 0,
@@ -92,7 +92,7 @@ export default {
     };
   },
   total: (data: API_RESPONSE) => ({
-    PEAKS: getEntry(data).newBalance ?? 0,
+    Peaks: getEntry(data).newBalance ?? 0,
   }),
   rank: (data: API_RESPONSE) => getEntry(data).overallRank ?? 0,
   supportedAddressTypes: ["evm"],

--- a/adapters/sierra.ts
+++ b/adapters/sierra.ts
@@ -1,0 +1,99 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://app.sierra.money/api/points/ledger?address={address}"
+);
+
+type SourceBreakdown = {
+  source?: string;
+  points?: number;
+};
+
+type LedgerEntry = {
+  address?: string;
+  epoch?: string;
+  newBalance?: number;
+  previousBalance?: number;
+  pointsThisWeek?: number;
+  overallRank?: number;
+  overallRankChange?: number;
+  weeklyRank?: number;
+  weeklyRankChange?: number;
+  lastUpdated?: number;
+  breakdown?: SourceBreakdown[];
+};
+
+type API_RESPONSE = {
+  epoch?: string;
+  metadata?: {
+    epoch?: string;
+    status?: string;
+    weekPointsDistributed?: number;
+    totalPointsDistributed?: number;
+    uniqueAddresses?: number;
+    generatedAt?: number;
+  };
+  entries?: LedgerEntry[];
+};
+
+const getEntry = (data: API_RESPONSE): LedgerEntry => data.entries?.[0] ?? {};
+
+const sourceLabel = (source: SourceBreakdown) =>
+  (source.source ?? "Unknown Source").replace(/-\d{4}-W\d{2}$/i, "");
+
+export default {
+  fetch: async (address: string) => {
+    const res = await fetch(
+      API_URL.replace("{address}", getAddress(address).toLowerCase()),
+      {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      }
+    );
+
+    const contentType = res.headers.get("content-type") ?? "";
+    if (!contentType.includes("application/json")) {
+      throw new Error("Sierra PEAKS endpoint returned a non-JSON response");
+    }
+
+    return await res.json();
+  },
+  data: (data: API_RESPONSE) => {
+    const entry = getEntry(data);
+    const sourceBreakdown: Record<string, number> = {};
+    for (const source of entry.breakdown ?? []) {
+      const label = sourceLabel(source);
+      sourceBreakdown[label] = (sourceBreakdown[label] ?? 0) + (source.points ?? 0);
+    }
+
+    return {
+      PEAKS: {
+        Total: entry.newBalance ?? 0,
+        "Previous Balance": entry.previousBalance ?? 0,
+        "This Week": entry.pointsThisWeek ?? 0,
+        "Overall Rank": entry.overallRank ?? 0,
+        "Overall Rank Change": entry.overallRankChange ?? 0,
+        "Weekly Rank": entry.weeklyRank ?? 0,
+        "Weekly Rank Change": entry.weeklyRankChange ?? 0,
+        Epoch: entry.epoch ?? data.epoch ?? "",
+        ...sourceBreakdown,
+      },
+      Program: {
+        Epoch: data.metadata?.epoch ?? data.epoch ?? "",
+        Status: data.metadata?.status ?? "",
+        "Week Points Distributed": data.metadata?.weekPointsDistributed ?? 0,
+        "Total Points Distributed": data.metadata?.totalPointsDistributed ?? 0,
+        "Unique Addresses": data.metadata?.uniqueAddresses ?? 0,
+      },
+    };
+  },
+  total: (data: API_RESPONSE) => ({
+    PEAKS: getEntry(data).newBalance ?? 0,
+  }),
+  rank: (data: API_RESPONSE) => getEntry(data).overallRank ?? 0,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/strata.ts
+++ b/adapters/strata.ts
@@ -1,0 +1,112 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { CORS_PROXY_URL, maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://api.strata.money/points/stats?accountAddress={address}&season=1&chainId=1"
+);
+
+type PointBucket = number | number[] | Record<string, number>;
+
+type StrataPoints = {
+  total?: number;
+  latest?: number;
+  supply?: number;
+  referral?: number;
+  tranche?: PointBucket;
+  pendle?: PointBucket;
+  pv2?: PointBucket;
+  euler?: PointBucket;
+  morpho?: PointBucket;
+  ipor?: PointBucket;
+  fluid?: PointBucket;
+  aave?: PointBucket;
+  rewards?: PointBucket;
+  sneutrl?: PointBucket;
+  pneutrl?: PointBucket;
+  pv3?: PointBucket;
+  smhyp?: PointBucket;
+  smm1?: PointBucket;
+  ssat?: PointBucket;
+};
+
+type API_RESPONSE = {
+  data?: {
+    account?: {
+      points?: StrataPoints;
+      rank?: number;
+    };
+  };
+};
+
+const sumBucket = (bucket: PointBucket | undefined): number => {
+  if (typeof bucket === "number") return bucket;
+  if (Array.isArray(bucket)) return bucket.reduce((total, value) => total + value, 0);
+  if (bucket && typeof bucket === "object") {
+    return Object.values(bucket).reduce((total, value) => total + value, 0);
+  }
+  return 0;
+};
+
+const getPoints = (data: API_RESPONSE): StrataPoints =>
+  data.data?.account?.points ?? {};
+
+const getHeaders = () => {
+  const headers: Record<string, string> = {
+    "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+  };
+
+  if (!API_URL.startsWith(CORS_PROXY_URL)) {
+    headers.Origin = "https://app.strata.markets";
+    headers.Referer = "https://app.strata.markets/points";
+  }
+
+  return headers;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: getHeaders(),
+    });
+
+    if (!res.ok) {
+      throw new Error(`Strata points request failed with status ${res.status}`);
+    }
+
+    return await res.json();
+  },
+  data: (data: API_RESPONSE) => {
+    const points = getPoints(data);
+
+    return {
+      Points: {
+        Total: points.total ?? 0,
+        Latest: points.latest ?? 0,
+        Supply: points.supply ?? 0,
+        Tranche: sumBucket(points.tranche),
+        Pendle: sumBucket(points.pendle),
+        "Pendle V2": sumBucket(points.pv2),
+        "Pendle V3": sumBucket(points.pv3),
+        Euler: sumBucket(points.euler),
+        Morpho: sumBucket(points.morpho),
+        IPOR: sumBucket(points.ipor),
+        Fluid: sumBucket(points.fluid),
+        Aave: sumBucket(points.aave),
+        Rewards: sumBucket(points.rewards),
+        "sNeutrl": sumBucket(points.sneutrl),
+        "pNeutrl": sumBucket(points.pneutrl),
+        "Midas mHYPER": sumBucket(points.smhyp),
+        "Midas mM1": sumBucket(points.smm1),
+        Saturn: sumBucket(points.ssat),
+        Referral: points.referral ?? 0,
+      },
+    };
+  },
+  total: (data: API_RESPONSE) => ({
+    Points: getPoints(data).total ?? 0,
+  }),
+  rank: (data: API_RESPONSE) => data.data?.account?.rank ?? 0,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/valantis.ts
+++ b/adapters/valantis.ts
@@ -1,0 +1,156 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_BASE_URL = await maybeWrapCORSProxy("https://api.fuul.xyz/api/v1");
+
+const POINTS_BEARER =
+  "db09744e57bb1884bbe7c9fe47a779117c39b655f43eb478fabe2277f7f1b5c6";
+
+const headers = {
+  accept: "application/json",
+  authorization: `Bearer ${POINTS_BEARER}`,
+  "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+};
+
+type LeaderboardEntry = {
+  total_amount?: number | string;
+  rank?: number;
+  total_attributions?: number;
+};
+
+type Movement = {
+  date: string;
+  conversion_name: string;
+  total_amount: string;
+  payout_status: string;
+};
+
+type LeaderboardResponse = {
+  results?: LeaderboardEntry[];
+  total_results?: number;
+  calculated_at?: string;
+};
+
+type MovementsResponse = {
+  results?: Movement[];
+  total_results?: number;
+};
+
+type API_RESPONSE = {
+  leaderboard: LeaderboardEntry;
+  leaderboardTotal: number;
+  calculatedAt?: string;
+  movements: Movement[];
+};
+
+const emptyLeaderboard = (): LeaderboardEntry => ({
+  total_amount: 0,
+  rank: 0,
+  total_attributions: 0,
+});
+
+const toNumber = (value: number | string | undefined): number => {
+  if (typeof value === "number") return Number.isFinite(value) ? value : 0;
+  if (!value) return 0;
+  return Number(value) || 0;
+};
+
+const formatMovementLabel = (movement: Movement): string => {
+  const date = new Date(movement.date);
+  const dateLabel = Number.isNaN(date.getTime())
+    ? movement.date
+    : date.toISOString().slice(0, 10);
+
+  return `${dateLabel} - ${movement.conversion_name}`;
+};
+
+const fetchJson = async <T>(path: string): Promise<T> => {
+  const res = await fetch(`${API_BASE_URL}${path}`, { headers });
+
+  if (res.status === 404) {
+    return { results: [], total_results: 0 } as T;
+  }
+
+  if (!res.ok) {
+    throw new Error(`Valantis request failed with status ${res.status}`);
+  }
+
+  return await res.json() as T;
+};
+
+const fetchMovements = async (address: string): Promise<Movement[]> => {
+  const pageSize = 100;
+  const results: Movement[] = [];
+  let totalResults = 0;
+
+  for (let page = 1; page <= 100; page += 1) {
+    const movementParams = new URLSearchParams({
+      user_identifier: address,
+      identifier_type: "evm_address",
+      type: "point",
+      page_size: String(pageSize),
+      page: String(page),
+    });
+    const response = await fetchJson<MovementsResponse>(
+      `/payouts/movements?${movementParams}`
+    );
+    const pageResults = response.results ?? [];
+
+    results.push(...pageResults);
+    totalResults = Math.max(totalResults, Number(response.total_results ?? 0));
+
+    if (pageResults.length === 0 || results.length >= totalResults) {
+      break;
+    }
+  }
+
+  return results;
+};
+
+const getMovementsTotal = (movements: Movement[]): number =>
+  movements.reduce((total, movement) => total + toNumber(movement.total_amount), 0);
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const params = new URLSearchParams({ user_identifier: normalizedAddress });
+
+    const [leaderboard, movements] = await Promise.all([
+      fetchJson<LeaderboardResponse>(`/payouts/leaderboard/points?${params}`),
+      fetchMovements(normalizedAddress),
+    ]);
+
+    return {
+      leaderboard: leaderboard.results?.[0] ?? emptyLeaderboard(),
+      leaderboardTotal: Number(leaderboard.total_results ?? 0),
+      calculatedAt: leaderboard.calculated_at,
+      movements,
+    };
+  },
+  data: (response: API_RESPONSE) => {
+    const totalPoints = getMovementsTotal(response.movements);
+    const breakdown = Object.fromEntries(
+      response.movements.map((movement) => [
+        formatMovementLabel(movement),
+        {
+          Points: toNumber(movement.total_amount),
+          Status: movement.payout_status,
+        },
+      ])
+    );
+
+    return {
+      Summary: {
+        Points: totalPoints,
+        Rank: Number(response.leaderboard.rank ?? 0),
+        "Total Attributions": Number(response.leaderboard.total_attributions ?? 0),
+        "Movement Count": response.movements.length,
+      },
+      ...breakdown,
+    };
+  },
+  total: (response: API_RESPONSE) => getMovementsTotal(response.movements),
+  rank: (response: API_RESPONSE) => Number(response.leaderboard.rank ?? 0),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;


### PR DESCRIPTION
## Summary
- Add adapters for IntegraLayer, Strata, APYX, Avant, Mainstreet, Sierra Protocol, Altura, and Valantis.
- Fetch and normalize each protocol's point totals, ranks, and season/source breakdowns for Checkpoint.

## Test plan
- Not run: this submodule does not define local package scripts.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Altura leaderboard integration for Season 4 and prior seasons
  * APYX points tracking and per-conversion totals
  * Avant / Merkl rewards campaign breakdowns and daily intake
  * Integralayer XP totals, breakdowns, and rank
  * Main Street per-season points, totals, and rank
  * Sierra PEAKS totals, sources, and program stats
  * Strata comprehensive points aggregation across buckets
  * Valantis leaderboard, movement history, and summary totals
  * Pear per-season leaderboard/points across multiple seasons
<!-- end of auto-generated comment: release notes by coderabbit.ai -->