### PR TITLE
Read Neynar API key from environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,8 @@ export default {
 }
 ```
 
+The function returns a record of `label`: `timestamp` which is in [UNIX time format](https://en.wikipedia.org/wiki/Unix_time). The labels are the same labels used in the adapter, if no labels are used by your other functions then use the label `Points`, which indicates that the points program has completely been deprecated.
+
 #### Changing CORS Proxy
 
 To change the CORS proxy used by the adapters in local development, use the env variable `CORS_PROXY_URL`.
@@ -223,4 +225,16 @@ To change the CORS proxy used by the adapters in local development, use the env 
 $ CORS_PROXY_URL="https://..." deno run ...
 ```
 
-The function returns a record of `label`: `timestamp` which is in [UNIX time format](https://en.wikipedia.org/wiki/Unix_time). The labels are the same labels used in the adapter, if no labels are used by your other functions then use the label `Points`, which indicates that the points program has completely been deprecated.
+#### Farcaster Neynar API Key
+
+Farcaster adapters that need to resolve a verified wallet address to an FID can
+use Neynar when an API key is configured. In Deno or Node runtimes, set
+`NEYNAR_API_KEY`:
+
+```sh
+$ NEYNAR_API_KEY="..." deno run ...
+```
+
+When adapters are bundled into a Vite browser app, set `VITE_NEYNAR_API_KEY`
+in the build environment. If no Neynar key is configured, the Farcaster helper
+falls back to the onchain custody-address lookup.

--- a/utils/cors.ts
+++ b/utils/cors.ts
@@ -47,4 +47,4 @@ const maybeWrapCORSProxy = async (url: string): Promise<string> => {
   return (await isGoodCORS(url)) ? url : wrapCORSProxy(url);
 };
 
-export { CORS_PROXY_URL, isGoodCORS, maybeWrapCORSProxy, wrapCORSProxy };
+export { CORS_PROXY_URL, isGoodCORS, maybeReadEnv, maybeWrapCORSProxy, wrapCORSProxy };

--- a/utils/farcaster.ts
+++ b/utils/farcaster.ts
@@ -50,6 +50,9 @@ const getFidByAddress = async (address: `0x${string}`): Promise<string> => {
   try {
     const normalized = address.toLowerCase();
     if (!NEYNAR_API_KEY) {
+      console.warn(
+        "NEYNAR_API_KEY not configured, falling back to onchain Farcaster ID lookup"
+      );
       return getFidFromIdRegistry(address);
     }
 

--- a/utils/farcaster.ts
+++ b/utils/farcaster.ts
@@ -1,13 +1,13 @@
 import { createPublicClient, fallback, http, parseAbi } from "viem";
 import { optimism } from "viem/chains";
-import { maybeWrapCORSProxy } from "./cors.ts";
+import { maybeReadEnv, maybeWrapCORSProxy } from "./cors.ts";
 
 const idRegistryAbi = parseAbi([
   "function idOf(address owner) view returns (uint256 fid)",
 ]);
 
 const ID_REGISTRY = "0x00000000fc6c5f01fc30151999387bb99a9f489b";
-const NEYNAR_API_KEY = "6DBA6F85-B88D-4DE5-8729-BDA3D7F22C81";
+const NEYNAR_API_KEY = maybeReadEnv("NEYNAR_API_KEY", "");
 const NEYNAR_BULK_BY_ADDRESS_RAW_URL =
   "https://api.neynar.com/v2/farcaster/user/bulk-by-address?addresses={address}";
 let neynarBulkByAddressUrl: Promise<string> | null = null;
@@ -49,6 +49,10 @@ const getFidFromIdRegistry = async (
 const getFidByAddress = async (address: `0x${string}`): Promise<string> => {
   try {
     const normalized = address.toLowerCase();
+    if (!NEYNAR_API_KEY) {
+      return getFidFromIdRegistry(address);
+    }
+
     const neynarUrl = await getNeynarBulkByAddressUrl();
     const res = await fetch(
       neynarUrl.replace("{address}", normalized),


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address (EVM or SVM) and an invalid address
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
0x... or SVM base58...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Neynar API Key configuration instructions for Deno/Node and browser environments
  * Clarified `deprecated` export format specifications for adapter labels

* **Improvements**
  * Enhanced Farcaster address resolution with automatic fallback to on-chain custody lookup when API key is unavailable

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0xPortalLabs/points-adapters/pull/96)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->