### PR TITLE
betrmint patch to EVM

### DIFF
--- a/adapters/betrmint.ts
+++ b/adapters/betrmint.ts
@@ -36,6 +36,6 @@ export default {
   total: (data: BetrmintData) => ({
     Karma: data.score ?? 0,
   }),
-  rank: (data: BetrmintData) => data.position || null,
+  rank: (data: BetrmintData) => (data.position > 0 ? data.position : null),
   supportedAddressTypes: ["evm"],
 } satisfies AdapterExport<BetrmintData>;

--- a/adapters/betrmint.ts
+++ b/adapters/betrmint.ts
@@ -2,17 +2,20 @@ import type { AdapterExport } from "../utils/adapter.ts";
 import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
 const API_URL = await maybeWrapCORSProxy(
-  "https://betrmint.fun/leaderboard/{fid}"
+  "https://betrmint.fun/leaderboard/{address}"
 );
 
 type BetrmintData = {
   position: number;
-  score: number;
+  score: number | null;
+  streak?: number;
+  staker?: boolean;
+  believer?: boolean;
 };
 
 export default {
-  fetch: async (fid: number) => {
-    const res = await fetch(API_URL.replace("{fid}", String(fid)), {
+  fetch: async (address: string) => {
+    const res = await fetch(API_URL.replace("{address}", address.toLowerCase()), {
       headers: {
         "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
       },
@@ -23,13 +26,16 @@ export default {
   },
   data: (data: BetrmintData) => ({
     Karma: {
-      Points: data.score,
+      Points: data.score ?? 0,
       Position: data.position,
+      Streak: data.streak ?? 0,
+      Staker: data.staker ?? false,
+      Believer: data.believer ?? false,
     },
   }),
   total: (data: BetrmintData) => ({
-    Karma: data.score,
+    Karma: data.score ?? 0,
   }),
-  rank: (data: BetrmintData) => data.position,
-  supportedAddressTypes: ["fid"],
+  rank: (data: BetrmintData) => data.position || null,
+  supportedAddressTypes: ["evm"],
 } satisfies AdapterExport<BetrmintData>;


### PR DESCRIPTION
## Summary
- Switch Betrmint lookup back to EVM wallet addresses to match the live Betrmint API
- Preserve Karma totals and include streak/staker/believer metadata
- Treat null scores as zero instead of leaking null into totals

## Verification
- Direct adapter check against a ranked Betrmint wallet returned Karma points
- Frontend production build passed from the parent app

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Betrmint adapter now supports querying by EVM address instead of Farcaster ID.
  * Additional metrics now available: Streak, Staker, and Believer fields.

* **Improvements**
  * Enhanced data handling with default values for missing scores and improved rank nullability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0xPortalLabs/points-adapters/pull/99)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->