### PR TITLE
fix doma, lombard, rainbow, sierra, treehouse

### DIFF
--- a/adapters/doma.ts
+++ b/adapters/doma.ts
@@ -6,7 +6,7 @@ import { convertKeysToStartCase } from "../utils/object.ts";
 const API_URL = await maybeWrapCORSProxy("https://api.doma.xyz/graphql");
 
 export default {
-  fetch: async (address) => {
+  fetch: async (address: string) => {
     const res = await fetch(API_URL, {
       method: "POST",
       headers: {
@@ -17,7 +17,7 @@ export default {
       },
       body: JSON.stringify({
         query:
-          "query LeaderboardByAddress($walletAddress: AddressCAIP10!, $weekNumber: Int, $season: LeaderboardSeason, $scope: LeaderboardScope) {  leaderboard(    walletAddress: $walletAddress    weekNumber: $weekNumber    season: $season    scope: $scope  ) {    points    rank    referralCount    referralPoints    referralBonusLimit    referralBonusesAwarded    tradingVolumeUsd    walletAddress    totalEntries    weekNumber    currentLevelThreshold    level    nextLevel    userMultiplier    nextThreshold    pointsMultiplier    closingDomaLevel    bonusPointsAwarded    seasonPoints    pointsByType {      TRADING      REFERRAL      QUEST      LEVEL_UP_BONUS      WEEKLY_REWARD      SNAPSHOT    }  }}",
+          "query LeaderboardByAddress($walletAddress: AddressCAIP10!, $weekNumber: Int, $season: LeaderboardSeason, $scope: LeaderboardScope) {  leaderboard(    walletAddress: $walletAddress    weekNumber: $weekNumber    season: $season    scope: $scope  ) {    points    rank    referralCount    referralPoints    walletAddress    totalEntries    weekNumber    currentLevelThreshold    level    nextLevel    userMultiplier    nextThreshold    pointsMultiplier    closingDomaLevel    bonusPointsAwarded    seasonPoints    pointsByType {      TRADING      REFERRAL      QUEST      LEVEL_UP_BONUS      WEEKLY_REWARD      SNAPSHOT    }  }}",
         variables: {
           walletAddress: `eip155:_:${getAddress(address)}`,
         },

--- a/adapters/lombard.ts
+++ b/adapters/lombard.ts
@@ -4,28 +4,13 @@ import { isEmpty } from "lodash-es";
 import { convertKeysToStartCase } from "../utils/object.ts";
 
 const API_URL = await maybeWrapCORSProxy(
-  "https://mainnet.prod.lombard.finance/api/v1/referral-system/season-2/points/{address}"
+  "https://mainnet.prod.lombard.finance/api/v1/referral-system/season-3/points/{address}"
 );
 
-// {
-//     "holding_points": 0.015005404,
-//     "protocol_points": 21.982641,
-//     "total": 1921.9977,
-//     "protocol_points_map": {
-//         "lombard-holding-points-eth": 0.015005404,
-//         "lombard-sonic-vault-eth": 21.982641
-//     },
-//     "badge_points": 1500,
-//     "checkin_points": 400
-// }
 type API_RESPONSE = {
-  holding_points: number;
-  protocol_points: number;
-  total: number;
   protocol_points_map: Record<string, number>;
-  badge_points: number;
-  checkin_points: number;
 };
+
 export default {
   fetch: async (address: string) => {
     const response = await fetch(API_URL.replace("{address}", address), {
@@ -34,27 +19,24 @@ export default {
       },
     });
     const data = await response.json();
+
     // API returns an empty object when address doesn't exist
     if (!data || isEmpty(data)) {
       return {
-        holding_points: 0,
-        protocol_points: 0,
-        total: 0,
         protocol_points_map: {},
-        badge_points: 0,
-        checkin_points: 0,
       };
     }
     return data;
   },
-  data: (data: API_RESPONSE) => {
-    return {
-      "Total Points": data.total,
-      ...convertKeysToStartCase(data.protocol_points_map),
-      "Badge Points": data.badge_points,
-      "Tap In Points": data.checkin_points,
-    };
-  },
-  total: (data: API_RESPONSE) => data.total,
+  data: (data: API_RESPONSE) => ({
+    Lux: { ...convertKeysToStartCase(data.protocol_points_map) },
+  }),
+  total: (data: API_RESPONSE) => ({
+    Lux: Object.values(data.protocol_points_map).reduce(
+      (sum, points) => sum + points,
+      0
+    ),
+  }),
+  claimable: () => true,
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/rainbow.ts
+++ b/adapters/rainbow.ts
@@ -3,26 +3,21 @@ import { maybeWrapCORSProxy } from "../utils/cors.ts";
 import { formatEther } from "viem";
 
 const API_URL = await maybeWrapCORSProxy(
-  "https://metadata.p.rainbow.me/v1/graph"
+  "https://metadata.p.rainbow.me/v1/graph",
 );
 
 type API_RESPONSE = {
   earnings: { total: number };
-  rewards: {
-    total: string;
-    claimable: number | string;
-    claimed: string;
-  };
-  stats: {
-    position: {
-      unranked: boolean;
-      current: number;
-    };
-  };
+  meta: { rewards: { total: string } };
+};
+
+const DEFAULT_RESPONSE: API_RESPONSE = {
+  earnings: { total: 0 },
+  meta: { rewards: { total: "0" } },
 };
 
 export default {
-  fetch: async (address) => {
+  fetch: async (address: string) => {
     const res = await fetch(API_URL, {
       headers: {
         "Content-Type": "application/json",
@@ -32,31 +27,11 @@ export default {
       method: "POST",
       body: JSON.stringify({
         query: `query getPointsDataForWallet($address: String!) {
-    points(address: $address) {
+    claimablePoints(address: $address) {
       error { message type }
-      meta { distribution { next } status rewards { total } }
-      leaderboard {
-        stats { total_users total_points rank_cutoff }
-        accounts { address earnings { total } ens avatarURL }
-      }
+      meta { rewards { total } }
       user {
-        referralCode
-        earnings_by_type { type earnings { total } }
         earnings { total }
-        rewards { total claimable claimed }
-        stats {
-          position { unranked current }
-          referral { total_referees qualified_referees }
-          last_airdrop {
-            position { unranked current }
-            earnings { total }
-            differences { type group_id earnings { total } }
-          }
-          last_period {
-            position { unranked current }
-            earnings { total }
-          }
-        }
       }
     }
   }`,
@@ -64,25 +39,22 @@ export default {
       }),
     });
     const data = await res.json();
-    return data.data.points.user;
+    const points = data.data?.claimablePoints;
+    if (!points) return DEFAULT_RESPONSE;
+
+    return { ...points.user, meta: points.meta };
   },
   data: (data: API_RESPONSE) => {
-    const isUnranked = data.stats.position.unranked;
-    const rank = isUnranked ? 0 : data.stats.position.current;
     const points = data.earnings.total;
-    const claimable = data.rewards.claimable;
+    const rewards = data.meta.rewards.total || "0";
 
     return {
       Points: points,
-      Rank: rank,
-      Unranked: isUnranked ? "Yes" : "No",
-      Claimable: claimable && claimable !== "0" ? "Yes" : "No",
-      Rewards: `${formatEther(BigInt(claimable))} ETH`,
+      Claimable: rewards !== "0" ? "Yes" : "No",
+      Rewards: `${formatEther(BigInt(rewards))} ETH`,
     };
   },
   total: (data: API_RESPONSE) => Number(data.earnings.total),
-  rank: (data: API_RESPONSE) =>
-    data.stats.position.unranked ? 0 : data.stats.position.current,
-  claimable: (data: API_RESPONSE) => Number(data.earnings.total) > 0,
+  claimable: (data: API_RESPONSE) => (data.meta.rewards.total || "0") !== "0",
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/sierra.ts
+++ b/adapters/sierra.ts
@@ -50,7 +50,9 @@ export default {
       {
         headers: {
           Accept: "application/json",
-          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+          // FIXME: They dont let use `Checkpoint API (https://checkpoint.exchange)` :(
+          "User-Agent":
+            "Mozilla/5.0 Checkpoint API (https://checkpoint.exchange/) Gecko",
         },
       }
     );
@@ -62,7 +64,8 @@ export default {
     const sourceBreakdown: Record<string, number> = {};
     for (const source of entry.breakdown ?? []) {
       const label = sourceLabel(source);
-      sourceBreakdown[label] = (sourceBreakdown[label] ?? 0) + (source.points ?? 0);
+      sourceBreakdown[label] =
+        (sourceBreakdown[label] ?? 0) + (source.points ?? 0);
     }
 
     return {

--- a/adapters/treehouse.ts
+++ b/adapters/treehouse.ts
@@ -1,77 +1,21 @@
 import type { AdapterExport } from "../utils/adapter.ts";
 
-import { startCase } from "lodash-es";
-
-const API_URL =
-  "https://api.treehouse.finance/gonuts-s2/weekly-points?address={address}";
-const S1_API_URL =
-  "https://api.treehouse.finance/gonuts-s1/nuts-accrued?address={address}";
-
-// {"message":"success","total_points_accrued_s1":8764.180039}
-/*
-  data: [
-    {
-      wallet_address: "0x69155e7ca2e688ccdc247f6c4ddf374b3ae77bd6",
-      total_weekly_points: 0.0010500000604928101,
-      week_start_date: "2025-07-14",
-      week_end_date: "2025-07-20",
-    },
-  ],
-  message: "success",
-  total_points_accrued: 0.007350000423449671,
-};
-*/
+// Points ended completely
+// ref: https://x.com/TreehouseFi/status/2049383503440281909
 export default {
-  fetch: async (address: string) => {
-    const headers = {
-      "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
-    };
-
-    const [s1, s2] = await Promise.all([
-      (
-        await fetch(S1_API_URL.replace("{address}", address), { headers })
-      ).json(),
-      (await fetch(API_URL.replace("{address}", address), { headers })).json(),
-    ]);
-
-    return { s1, s2 };
-  },
-  data: ({
-    s1,
-    s2,
-  }: {
-    s1: Record<string, unknown>;
-    s2: Record<string, unknown>;
-  }) => {
-    const s2Data: Record<string, string | number> = {};
-    if (s2?.data && Array.isArray(s2.data)) {
-      s2.data.forEach((obj: Record<string, unknown>, idx: number) => {
-        delete obj.wallet_address;
-
-        Object.entries(obj).forEach(([k, v]) => {
-          s2Data[`Week ${idx + 1} ${startCase(k)}`] = v as string | number;
-        });
-      });
-    }
-
-    return {
-      "S1 Nuts": {
-        "Total Points": s1.total_points_accrued_s1 as string | number,
-      },
-      "S2 Weekly Points": s2Data,
-    };
-  },
-  total: ({
-    s1,
-    s2,
-  }: {
-    s1: Record<string, unknown>;
-    s2: Record<string, unknown>;
-  }) => {
-    return {
-      "S1 Nuts": s1?.total_points_accrued_s1,
-      "S2 Weekly Points": s2?.total_points_accrued,
-    };
-  },
+  fetch: () => Promise.resolve({}),
+  data: () => ({
+    "S1 Nuts": {},
+    "S2 Weekly Points": {},
+  }),
+  total: () => ({
+    "S1 Nuts": 0,
+    "S2 Weekly Points": 0,
+  }),
+  claimable: () => true,
+  deprecated: () => ({
+    "S1 Nuts": 1777446077, // Apr 29th 07:01 UTC
+    "S2 Weekly Points": 1777446077, // Apr 29th 07:01 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Doma adapter: Updated points query selection.
  * Lombard adapter: Migrated to new season-3 API endpoint with revised data handling.
  * Rainbow adapter: Updated to display claimable points; removed rank field.
  * Sierra adapter: Improved request formatting.

* **Deprecated**
  * Treehouse adapter: No longer fetches live data; marked as deprecated.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0xPortalLabs/points-adapters/pull/100)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->