### PR TITLE
Add saturn

### DIFF
--- a/adapters/saturn.ts
+++ b/adapters/saturn.ts
@@ -14,15 +14,21 @@ type Reward = {
   };
 };
 
-type API_RESPONSE = { rewards: Reward[] }[];
-
-const getRewards = (data: API_RESPONSE) =>
-  data
-    .flatMap((chain) => chain.rewards)
-    .filter((x) => x.token.address.toLowerCase() === GRAVITY_POINTS_ADDRESS);
+type API_RESPONSE = Reward[];
 
 const toAmount = (value: string, decimals: number) =>
   Number(value) / 10 ** decimals;
+
+const getDetails = (data: API_RESPONSE) =>
+  data.reduce(
+    (totals, x) => {
+      totals.Amount += toAmount(x.amount, x.token.decimals);
+      totals.Claimed += toAmount(x.claimed, x.token.decimals);
+      totals.Pending += toAmount(x.pending, x.token.decimals);
+      return totals;
+    },
+    { Amount: 0, Claimed: 0, Pending: 0 }
+  );
 
 export default {
   fetch: async (address: string) => {
@@ -33,33 +39,17 @@ export default {
       },
     });
 
-    return await res.json();
+    // Filter for only Gravity Points.
+    return ((await res.json()) as { rewards: Reward[] }[])
+      .flatMap((chain) => chain.rewards)
+      .filter((x) => x.token.address.toLowerCase() === GRAVITY_POINTS_ADDRESS);
   },
-  data: (data: API_RESPONSE) => {
-    return Object.fromEntries(
-      getRewards(data).map((x) => {
-        return [
-          POINTS_NAME,
-          {
-            Amount: toAmount(x.amount, x.token.decimals),
-            Claimed: toAmount(x.claimed, x.token.decimals),
-            Pending: toAmount(x.pending, x.token.decimals),
-          },
-        ];
-      })
-    );
-  },
+  data: (data: API_RESPONSE) => ({ [POINTS_NAME]: getDetails(data) }),
   total: (data: API_RESPONSE) => {
-    return getRewards(data).reduce(
-      (totals, x) => {
-        totals[POINTS_NAME] =
-          (totals[POINTS_NAME] ?? 0) +
-          toAmount(x.amount, x.token.decimals) +
-          toAmount(x.pending, x.token.decimals);
-        return totals;
-      },
-      { "Gravity Points": 0 }
-    );
+    const details = getDetails(data);
+    return {
+      [POINTS_NAME]: details.Amount + details.Pending,
+    };
   },
   supportedAddressTypes: ["evm"],
 } satisfies AdapterExport<API_RESPONSE>;

--- a/adapters/saturn.ts
+++ b/adapters/saturn.ts
@@ -50,13 +50,16 @@ export default {
     );
   },
   total: (data: API_RESPONSE) => {
-    return getRewards(data).reduce((totals, x) => {
-      totals[POINTS_NAME] =
-        (totals[POINTS_NAME] ?? 0) +
-        toAmount(x.amount, x.token.decimals) +
-        toAmount(x.pending, x.token.decimals);
-      return totals;
-    }, {} as Record<string, number>);
+    return getRewards(data).reduce(
+      (totals, x) => {
+        totals[POINTS_NAME] =
+          (totals[POINTS_NAME] ?? 0) +
+          toAmount(x.amount, x.token.decimals) +
+          toAmount(x.pending, x.token.decimals);
+        return totals;
+      },
+      { "Gravity Points": 0 }
+    );
   },
   supportedAddressTypes: ["evm"],
 } satisfies AdapterExport<API_RESPONSE>;

--- a/adapters/saturn.ts
+++ b/adapters/saturn.ts
@@ -1,0 +1,62 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+
+const API_URL = "https://api.merkl.xyz/v4/users/{address}/rewards?chainId=1";
+const GRAVITY_POINTS_ADDRESS = "0xd223bbdd0421e394c0df9dffe568f1dadffd6f85";
+const POINTS_NAME = "Gravity Points";
+
+type Reward = {
+  amount: string;
+  claimed: string;
+  pending: string;
+  token: {
+    address: string;
+    decimals: number;
+  };
+};
+
+type API_RESPONSE = { rewards: Reward[] }[];
+
+const getRewards = (data: API_RESPONSE) =>
+  data
+    .flatMap((chain) => chain.rewards)
+    .filter((x) => x.token.address.toLowerCase() === GRAVITY_POINTS_ADDRESS);
+
+const toAmount = (value: string, decimals: number) =>
+  Number(value) / 10 ** decimals;
+
+export default {
+  fetch: async (address: string) => {
+    address = address.toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", address), {
+      headers: {
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    return await res.json();
+  },
+  data: (data: API_RESPONSE) => {
+    return Object.fromEntries(
+      getRewards(data).map((x) => {
+        return [
+          POINTS_NAME,
+          {
+            Amount: toAmount(x.amount, x.token.decimals),
+            Claimed: toAmount(x.claimed, x.token.decimals),
+            Pending: toAmount(x.pending, x.token.decimals),
+          },
+        ];
+      })
+    );
+  },
+  total: (data: API_RESPONSE) => {
+    return getRewards(data).reduce((totals, x) => {
+      totals[POINTS_NAME] =
+        (totals[POINTS_NAME] ?? 0) +
+        toAmount(x.amount, x.token.decimals) +
+        toAmount(x.pending, x.token.decimals);
+      return totals;
+    }, {} as Record<string, number>);
+  },
+  supportedAddressTypes: ["evm"],
+} satisfies AdapterExport<API_RESPONSE>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [x] Enable "Allow edits by maintainers" on this PR
- [x] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [x] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [x] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [x] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):** 0xf3dcaeb909d3d17318c0908a1ec0ca31321e1672

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points: 1048236520.4724078 (1.05b)
- Rank: n/a

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:** saturn
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Saturn/Merkl Gravity Points rewards. Users with EVM addresses can now retrieve and view Gravity Points balances, see claimed and pending amounts, and view aggregated totals per points type. Rewards are presented in clear numeric amounts for easy tracking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/0xPortalLabs/points-adapters/pull/101?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->