### PR TITLE
deprecated protocols

### DIFF
--- a/adapters/kelpdao.ts
+++ b/adapters/kelpdao.ts
@@ -15,7 +15,7 @@ export default {
         headers: {
           "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
         },
-      }
+      },
     );
     return (await res.json()).value;
   },
@@ -27,5 +27,8 @@ export default {
   }),
   claimable: ({ kelpMiles }: { kelpMiles: string }) =>
     parseFloat(kelpMiles) > 0,
+  deprecated: () => ({
+    "Kernel Points": 1772236800, // February 28th 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/level.ts
+++ b/adapters/level.ts
@@ -6,5 +6,8 @@ export default {
   data: () => ({}),
   total: () => 0,
   claimable: () => false,
+  deprecated: () => ({
+    Points: 1780876800, // June 8th 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/megaeth.ts
+++ b/adapters/megaeth.ts
@@ -2,13 +2,15 @@ import type { AdapterExport } from "../utils/adapter.ts";
 import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
 const LEADERBOARD_URL = await maybeWrapCORSProxy(
-  "https://terminal.megaeth.com/leaderboard"
+  "https://terminal.megaeth.com/leaderboard",
 );
 
 const headers = {
   "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
   Accept: "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
 };
+
+const CLAIM_DEADLINE = 1781049600; // June 10th 2026 00:00 UTC
 
 type LeaderboardEntry = {
   rank: number;
@@ -46,7 +48,7 @@ const findEntryInSection = (
   html: string,
   lowerCaseAddress: string,
   sectionStart: number,
-  searchEnd: number
+  searchEnd: number,
 ): LeaderboardEntry | undefined => {
   const addressStart = html.indexOf(lowerCaseAddress, sectionStart);
 
@@ -64,7 +66,7 @@ const findEntryInSection = (
 
 const readLeaderboardEntries = async (
   res: Response,
-  lowerCaseAddress: string
+  lowerCaseAddress: string,
 ): Promise<Pick<AdapterResponse, "weekly" | "allTime">> => {
   const html = await res.text();
   const { weeklyStart, allStart } = findLeaderboardBounds(html);
@@ -74,6 +76,9 @@ const readLeaderboardEntries = async (
     allTime: findEntryInSection(html, lowerCaseAddress, allStart, html.length),
   };
 };
+
+const getTotalPoints = (data: AdapterResponse) =>
+  data.allTime?.totalPoints ?? data.weekly?.totalPoints ?? 0;
 
 export default {
   fetch: async (address: string) => {
@@ -90,13 +95,14 @@ export default {
     };
   },
   data: (data: AdapterResponse) => ({
-    "Total Points": data.allTime?.totalPoints ?? data.weekly?.totalPoints ?? 0,
+    "Total Points": getTotalPoints(data),
     Rank: data.allTime?.rank ?? 0,
     "Weekly Points": data.weekly?.weeklyPointsChange ?? 0,
     "Weekly Rank": data.weekly?.rank ?? 0,
   }),
-  total: (data: AdapterResponse) =>
-    data.allTime?.totalPoints ?? data.weekly?.totalPoints ?? 0,
+  total: (data: AdapterResponse) => getTotalPoints(data),
   rank: (data: AdapterResponse) => data.allTime?.rank ?? 0,
+  claimable: (data: AdapterResponse) =>
+    Date.now() < CLAIM_DEADLINE * 1000 && getTotalPoints(data) > 0,
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/ramen.ts
+++ b/adapters/ramen.ts
@@ -8,5 +8,8 @@ export default {
   data: () => ({}),
   total: () => 0,
   claimable: () => false,
+  deprecated: () => ({
+    Points: 1780876800, // June 8th 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/resolv.ts
+++ b/adapters/resolv.ts
@@ -6,10 +6,10 @@ import { maybeWrapCORSProxy } from "../utils/cors.ts";
 // NOTE: API for leaderboard
 // https://api.resolv.im/points/leaderboard?page=1
 const API_URL = await maybeWrapCORSProxy(
-  "https://web-api.resolv.xyz/points?address={address}"
+  "https://web-api.resolv.xyz/points?address={address}",
 );
 const RANK_URL = await maybeWrapCORSProxy(
-  "https://web-api.resolv.xyz/points/leaderboard/slice?address={address}"
+  "https://web-api.resolv.xyz/points/leaderboard/slice?address={address}",
 );
 
 /*
@@ -63,6 +63,9 @@ export default {
   data: ({ data }: { data: { dailyActivities: Record<string, number> } }) =>
     convertKeysToStartCase(data.dailyActivities),
   total: ({ data }: { data: { totalPoints: number } }) => data.totalPoints,
+  deprecated: () => ({
+    Points: 1780876800, // June 8th 2026 00:00 UTC
+  }),
   rank: ({
     rankData,
   }: {

--- a/adapters/sonic.ts
+++ b/adapters/sonic.ts
@@ -2,7 +2,7 @@ import type { AdapterExport } from "../utils/adapter.ts";
 import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
 const API_URL = await maybeWrapCORSProxy(
-  "https://www.data-openblocklabs.com/sonic/user-points-stats?wallet_address={address}"
+  "https://www.data-openblocklabs.com/sonic/user-points-stats?wallet_address={address}",
 );
 
 /**
@@ -29,7 +29,7 @@ export default {
   },
   data: (data: Record<string, number>) => ({
     "User Activity Last Detected": new Date(
-      data.user_activity_last_detected
+      data.user_activity_last_detected,
     ).toString(),
     "Sonic Points": data.sonic_points,
     "Loyalty Multiplier": data.loyalty_multiplier,
@@ -40,5 +40,8 @@ export default {
   }),
   total: (data: Record<string, number>) => data.sonic_points,
   rank: (data: { rank: number }) => data.rank,
+  deprecated: () => ({
+    Points: 1761955200, // November 1st 2025 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/superform.ts
+++ b/adapters/superform.ts
@@ -2,7 +2,7 @@ import type { AdapterExport } from "../utils/adapter.ts";
 import { maybeWrapCORSProxy } from "../utils/cors.ts";
 
 const API_URL = await maybeWrapCORSProxy(
-  "https://persephone.superform.xyz/v1/rewards/summary/{address}?epoch={epoch}"
+  "https://persephone.superform.xyz/v1/rewards/summary/{address}?epoch={epoch}",
 );
 
 const CHECKPOINT_USER_AGENT = "Checkpoint API (https://checkpoint.exchange)";
@@ -30,7 +30,7 @@ export default {
     const fetchSummary = async (epoch: number): Promise<SuperformSummary> => {
       const url = API_URL.replace("{address}", address).replace(
         "{epoch}",
-        String(epoch)
+        String(epoch),
       );
 
       return await (
@@ -65,5 +65,8 @@ export default {
     "S3 Points": epoch2.user.points,
   }),
   rank: ({ epoch2 }: SuperformFetchResponse) => Number(epoch2.user.rank),
+  deprecated: () => ({
+    "S3 Points": 1780876800, // June 8th 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;

--- a/adapters/valantis.ts
+++ b/adapters/valantis.ts
@@ -93,7 +93,7 @@ const fetchMovements = async (address: string): Promise<Movement[]> => {
       page: String(page),
     });
     const response = await fetchJson<MovementsResponse>(
-      `/payouts/movements?${movementParams}`
+      `/payouts/movements?${movementParams}`,
     );
     const pageResults = response.results ?? [];
 
@@ -109,7 +109,10 @@ const fetchMovements = async (address: string): Promise<Movement[]> => {
 };
 
 const getMovementsTotal = (movements: Movement[]): number =>
-  movements.reduce((total, movement) => total + toNumber(movement.total_amount), 0);
+  movements.reduce(
+    (total, movement) => total + toNumber(movement.total_amount),
+    0,
+  );
 
 export default {
   fetch: async (address: string) => {
@@ -137,14 +140,16 @@ export default {
           Points: toNumber(movement.total_amount),
           Status: movement.payout_status,
         },
-      ])
+      ]),
     );
 
     return {
       Summary: {
         Points: totalPoints,
         Rank: Number(response.leaderboard.rank ?? 0),
-        "Total Attributions": Number(response.leaderboard.total_attributions ?? 0),
+        "Total Attributions": Number(
+          response.leaderboard.total_attributions ?? 0,
+        ),
         "Movement Count": response.movements.length,
       },
       ...breakdown,
@@ -152,5 +157,8 @@ export default {
   },
   total: (response: API_RESPONSE) => getMovementsTotal(response.movements),
   rank: (response: API_RESPONSE) => Number(response.leaderboard.rank ?? 0),
+  deprecated: () => ({
+    Points: 1780531200, // June 4th 2026 00:00 UTC
+  }),
   supportedAddressTypes: ["evm"],
 } as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Deprecations**
  * Multiple point system adapters have been marked as deprecated with specific end-of-service dates, ranging from November 2025 through June 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->