### PR TITLE
Add OneBanking adapter

### DIFF
--- a/adapters/onebanking.ts
+++ b/adapters/onebanking.ts
@@ -1,0 +1,54 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const WEBSITE_ID = "08972bb4-3d25-4097-b5bf-bebb4b88703e";
+const ORGANIZATION_ID = "bdc4243b-9939-4713-befc-1606909f1c6e";
+const LOYALTY_CURRENCY_ID = "bbd4b7f7-1e8b-404c-b795-ebb341678752";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://quests.onebanking.app/api/loyalty/accounts" +
+    `?websiteId=${WEBSITE_ID}` +
+    `&organizationId=${ORGANIZATION_ID}` +
+    `&loyaltyCurrencyId=${LOYALTY_CURRENCY_ID}` +
+    "&walletAddress={address}" +
+    "&limit=1",
+);
+
+type OneBankingAccount = {
+  amount?: string;
+  updatedAt?: string;
+};
+
+type OneBankingResponse = {
+  data?: OneBankingAccount[];
+};
+
+const getPoints = (data: OneBankingResponse): number =>
+  Number(data.data?.[0]?.amount ?? 0) || 0;
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `OneBanking points request failed with status ${res.status}`,
+      );
+    }
+
+    return await res.json() as OneBankingResponse;
+  },
+  data: (data: OneBankingResponse) => ({
+    "OneBanking Points": getPoints(data),
+    "Last Updated": data.data?.[0]?.updatedAt ?? "N/A",
+  }),
+  total: getPoints,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OneBanking Points adapter supporting EVM addresses, enabling users to fetch and view OneBanking Points data with formatted display of current points and last updated information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->