### PR TITLE
Add Tori adapter

### DIFF
--- a/adapters/tori.ts
+++ b/adapters/tori.ts
@@ -1,0 +1,47 @@
+import { getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://app.tori.finance/api/points/me?address={address}",
+);
+
+type ToriPointsResponse = {
+  totalCores?: number;
+  totalEarnings?: number;
+  ecosystemBalance?: number | null;
+  costBasis?: number;
+  netShares?: number;
+};
+
+const getCores = (data: ToriPointsResponse): number =>
+  Number(data.totalCores ?? 0) || 0;
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const res = await fetch(API_URL.replace("{address}", normalizedAddress), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Tori points request failed with status ${res.status}`);
+    }
+
+    return await res.json() as ToriPointsResponse;
+  },
+  data: (data: ToriPointsResponse) => ({
+    Cores: getCores(data),
+    "Total Earnings": Number(data.totalEarnings ?? 0) || 0,
+    "Ecosystem Balance": Number(data.ecosystemBalance ?? 0) || 0,
+    "Cost Basis": Number(data.costBasis ?? 0) || 0,
+    "Net Shares": Number(data.netShares ?? 0) || 0,
+  }),
+  total: (data: ToriPointsResponse) => ({
+    Cores: getCores(data),
+  }),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Tori point lookups.
  * Enabled EVM address handling for this integration.
  * Added standardized point totals and balance fields for consistent display.

* **Bug Fixes**
  * Improved address normalization before making requests.
  * Added clearer handling for unsuccessful API responses.
  * Included numeric fallbacks to help avoid missing or invalid values in results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->