### PR TITLE
Add Makina points adapter

### DIFF
--- a/adapters/makina.ts
+++ b/adapters/makina.ts
@@ -44,18 +44,14 @@ const getDetails = (data: MakinaData) =>
       const claimed = toPoints(reward.claimed, reward.token.decimals);
       const pending = toPoints(reward.pending, reward.token.decimals);
 
-      totals.Amount += amount;
-      totals.Claimed += claimed;
-      totals.Pending += pending;
+      totals.Total += amount + pending;
       totals["Merkl Amount"] += amount;
       totals["Merkl Claimed"] += claimed;
       totals["Merkl Pending"] += pending;
       return totals;
     },
     {
-      Amount: data.season0Points,
-      Claimed: 0,
-      Pending: 0,
+      Total: data.season0Points,
       "Season 0": data.season0Points,
       "Merkl Amount": 0,
       "Merkl Claimed": 0,
@@ -114,7 +110,7 @@ export default {
   total: (data: MakinaData) => {
     const details = getDetails(data);
     return {
-      [POINTS_NAME]: details.Amount + details.Pending,
+      [POINTS_NAME]: details.Total,
     };
   },
   supportedAddressTypes: ["evm"],

--- a/adapters/makina.ts
+++ b/adapters/makina.ts
@@ -1,0 +1,121 @@
+import { formatUnits, getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const SEASON_0_API_URL = await maybeWrapCORSProxy(
+  "https://makina.finance/api/points/{address}",
+);
+const MERKL_API_URL = await maybeWrapCORSProxy("https://api.merkl.xyz/v4");
+
+const INK_CHAIN_ID = 57073;
+const MAKINA_POINTS_ADDRESS = "0x3419966bC74fa8f951108d15b053bEd233974d3D";
+const POINTS_NAME = "Makina Points";
+
+type Season0Response = {
+  season0Points?: number;
+};
+
+type MerklReward = {
+  amount: string;
+  claimed: string;
+  pending: string;
+  token: {
+    address: string;
+    decimals: number;
+  };
+};
+
+type MerklUserRewards = Array<{
+  rewards: MerklReward[];
+}>;
+
+type MakinaData = {
+  season0Points: number;
+  rewards: MerklReward[];
+};
+
+const toPoints = (value: string, decimals: number) =>
+  parseFloat(formatUnits(BigInt(value), decimals));
+
+const getDetails = (data: MakinaData) =>
+  data.rewards.reduce(
+    (totals, reward) => {
+      const amount = toPoints(reward.amount, reward.token.decimals);
+      const claimed = toPoints(reward.claimed, reward.token.decimals);
+      const pending = toPoints(reward.pending, reward.token.decimals);
+
+      totals.Amount += amount;
+      totals.Claimed += claimed;
+      totals.Pending += pending;
+      totals["Merkl Amount"] += amount;
+      totals["Merkl Claimed"] += claimed;
+      totals["Merkl Pending"] += pending;
+      return totals;
+    },
+    {
+      Amount: data.season0Points,
+      Claimed: 0,
+      Pending: 0,
+      "Season 0": data.season0Points,
+      "Merkl Amount": 0,
+      "Merkl Claimed": 0,
+      "Merkl Pending": 0,
+    },
+  );
+
+export default {
+  fetch: async (address: string): Promise<MakinaData> => {
+    const normalizedAddress = getAddress(address).toLowerCase();
+    const url = new URL(`${MERKL_API_URL}/users/${normalizedAddress}/rewards`);
+    url.searchParams.set("chainId", String(INK_CHAIN_ID));
+
+    const [season0Res, merklRes] = await Promise.all([
+      fetch(SEASON_0_API_URL.replace("{address}", normalizedAddress), {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      }),
+      fetch(url.toString(), {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      }),
+    ]);
+
+    if (!season0Res.ok) {
+      throw new Error(
+        `Makina season 0 points request failed with status ${season0Res.status}`,
+      );
+    }
+
+    if (!merklRes.ok) {
+      throw new Error(
+        `Makina Merkl points request failed with status ${merklRes.status}`,
+      );
+    }
+
+    const season0 = await season0Res.json() as Season0Response;
+    const merkl = await merklRes.json() as MerklUserRewards;
+
+    return {
+      season0Points: Number(season0.season0Points ?? 0) || 0,
+      rewards: merkl
+        .flatMap((chain) => chain.rewards)
+        .filter(
+          (reward) =>
+            reward.token.address.toLowerCase() ===
+              MAKINA_POINTS_ADDRESS.toLowerCase(),
+        ),
+    };
+  },
+  data: (data: MakinaData) => ({ [POINTS_NAME]: getDetails(data) }),
+  total: (data: MakinaData) => {
+    const details = getDetails(data);
+    return {
+      [POINTS_NAME]: details.Amount + details.Pending,
+    };
+  },
+  supportedAddressTypes: ["evm"],
+} as AdapterExport<MakinaData>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Makina Points, combining Season 0 points with Merkl user rewards.
  * Introduced a Makina Points view with total, claimed, and pending amounts, including a Merkl breakdown.
  * Limited this data source to EVM addresses and aggregates reward amounts into the displayed totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->