### PR TITLE
Add shMONAD points adapter

### DIFF
--- a/adapters/shmonad.ts
+++ b/adapters/shmonad.ts
@@ -1,0 +1,66 @@
+import { formatUnits, getAddress } from "viem";
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const MERKL_API_URL = await maybeWrapCORSProxy("https://api.merkl.xyz/v4");
+
+const MONAD_CHAIN_ID = 143;
+const SHMON_POINTS_ADDRESS = "0xCdEF0ED16c5800025B26908b3Be9e6Ad4Ef187a5";
+const SHMON_POINTS_DECIMALS = 18;
+const POINTS_NAME = "shMON Points";
+
+type Reward = {
+  amount: string;
+  claimed: string;
+  pending: string;
+  recipient: string;
+};
+
+type API_RESPONSE = Reward[];
+
+const toAmount = (value: string) =>
+  parseFloat(formatUnits(BigInt(value), SHMON_POINTS_DECIMALS));
+
+const getDetails = (data: API_RESPONSE) =>
+  data.reduce(
+    (totals, reward) => {
+      totals.Amount += toAmount(reward.amount);
+      totals.Claimed += toAmount(reward.claimed);
+      totals.Pending += toAmount(reward.pending);
+      return totals;
+    },
+    { Amount: 0, Claimed: 0, Pending: 0 },
+  );
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = getAddress(address);
+    const url = new URL(`${MERKL_API_URL}/rewards/token/`);
+    url.searchParams.set("chainId", String(MONAD_CHAIN_ID));
+    url.searchParams.set("address", SHMON_POINTS_ADDRESS);
+    url.searchParams.set("recipient", normalizedAddress);
+    url.searchParams.set("page", "0");
+    url.searchParams.set("items", "20");
+
+    const res = await fetch(url.toString(), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`shMON points request failed with status ${res.status}`);
+    }
+
+    return await res.json() as API_RESPONSE;
+  },
+  data: (data: API_RESPONSE) => ({ [POINTS_NAME]: getDetails(data) }),
+  total: (data: API_RESPONSE) => {
+    const details = getDetails(data);
+    return {
+      [POINTS_NAME]: details.Amount,
+    };
+  },
+  supportedAddressTypes: ["evm"],
+} as AdapterExport<API_RESPONSE>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for viewing `shMON Points` rewards on Monad addresses.
  * Reward balances are now fetched from the rewards API and shown as total, claimed, and pending amounts.
  * EVM addresses are supported for this new points source.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->