### PR TITLE
Add Re, Fairground, and Ondo points adapters

### DIFF
--- a/adapters/fairground.ts
+++ b/adapters/fairground.ts
@@ -1,0 +1,95 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://incentives.fairground.fi/api/v1/user_scores",
+);
+
+type LeaderboardEntry = {
+  owner?: string;
+  rank?: number;
+  updated_at?: string;
+  earned_xp?: number;
+  epoch_number?: number;
+  fees_score?: number;
+  participation_score?: number;
+  pnl_score?: number;
+  rebate_score?: number;
+  season_id?: number;
+  total_bonus_score?: number;
+  total_score?: number;
+  previous_total_score?: number;
+};
+
+type LeaderboardResponse = {
+  data?: LeaderboardEntry[];
+};
+
+const emptyEntry = (): LeaderboardEntry => ({
+  rank: 0,
+  earned_xp: 0,
+  epoch_number: 0,
+  fees_score: 0,
+  participation_score: 0,
+  pnl_score: 0,
+  rebate_score: 0,
+  season_id: 0,
+  total_bonus_score: 0,
+  total_score: 0,
+  previous_total_score: 0,
+});
+
+const getSeasonXP = (entry: LeaderboardEntry): number =>
+  Number(entry.total_score ?? 0);
+
+export default {
+  fetch: async (address: string) => {
+    const normalizedAddress = address.toLowerCase();
+    const params = new URLSearchParams({
+      page: "1",
+      page_size: "1",
+      "filters[0][field]": "owner",
+      "filters[0][op]": "ilike_and",
+      "filters[0][value]": normalizedAddress,
+    });
+
+    const res = await fetch(`${API_URL}?${params}`, {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(
+        `Fairground leaderboard request failed with status ${res.status}`,
+      );
+    }
+
+    const response = await res.json() as LeaderboardResponse;
+    return response.data?.find(
+      (entry) => entry.owner?.toLowerCase() === normalizedAddress,
+    ) ?? emptyEntry();
+  },
+  data: (entry: LeaderboardEntry) => ({
+    "Season XP": {
+      Total: getSeasonXP(entry),
+      Rank: Number(entry.rank ?? 0),
+      "Season ID": Number(entry.season_id ?? 0),
+      "Latest Scored Epoch": Number(entry.epoch_number ?? 0),
+      "Latest Epoch XP": Number(entry.earned_xp ?? 0),
+      "Previous Total": Number(entry.previous_total_score ?? 0),
+      "Fees XP": Number(entry.fees_score ?? 0),
+      "Participation XP": Number(entry.participation_score ?? 0),
+      "PnL XP": Number(entry.pnl_score ?? 0),
+      "Rebate XP": Number(entry.rebate_score ?? 0),
+      "Bonus XP": Number(entry.total_bonus_score ?? 0),
+      "Last Updated": entry.updated_at ?? "N/A",
+    },
+  }),
+  total: (entry: LeaderboardEntry) => ({
+    "Season XP": getSeasonXP(entry),
+  }),
+  rank: (entry: LeaderboardEntry) => Number(entry.rank ?? 0),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/ondo.ts
+++ b/adapters/ondo.ts
@@ -1,0 +1,53 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://ondo.foundation/api/my_points?address={address}",
+);
+
+type OndoPointsResponse = {
+  hip3TraderPoints?: string;
+  perpsPoints?: string;
+  totalPoints?: string;
+  participatingCampaigns?: number;
+  rank?: number | null;
+  updatedAt?: string;
+};
+
+const toNumber = (value: string | number | undefined): number =>
+  Number(value ?? 0) || 0;
+
+export default {
+  fetch: async (address: string) => {
+    const res = await fetch(
+      API_URL.replace("{address}", address.toLowerCase()),
+      {
+        headers: {
+          Accept: "application/json",
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      },
+    );
+
+    if (!res.ok) {
+      throw new Error(`Ondo points request failed with status ${res.status}`);
+    }
+
+    return await res.json() as OndoPointsResponse;
+  },
+  data: (data: OndoPointsResponse) => ({
+    "Ondo Points": {
+      Total: toNumber(data.totalPoints),
+      "Ondo Perps Points": toNumber(data.perpsPoints),
+      "HIP-3 Trader Points": toNumber(data.hip3TraderPoints),
+      "Participating Campaigns": Number(data.participatingCampaigns ?? 0),
+      "Global Rank": Number(data.rank ?? 0),
+      "Last Updated": data.updatedAt ?? "N/A",
+    },
+  }),
+  total: (data: OndoPointsResponse) => ({
+    "Ondo Points": toNumber(data.totalPoints),
+  }),
+  rank: (data: OndoPointsResponse) => Number(data.rank ?? 0),
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;

--- a/adapters/re.ts
+++ b/adapters/re.ts
@@ -1,0 +1,48 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://api.re.xyz/wallet/points?address={address}",
+);
+
+type RePointsResponse = {
+  success: boolean;
+  address: string;
+  season: number;
+  points: number;
+  rank: number | null;
+  share: number | null;
+  last_update: string | null;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const res = await fetch(API_URL.replace("{address}", address), {
+      headers: {
+        Accept: "application/json",
+        "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+      },
+    });
+
+    if (!res.ok) {
+      throw new Error(`Re points request failed with status ${res.status}`);
+    }
+
+    const data = await res.json() as RePointsResponse;
+    if (!data.success) {
+      throw new Error("Re points request was unsuccessful");
+    }
+
+    return data;
+  },
+  data: (data: RePointsResponse) => ({
+    "Re Points": data.points,
+    Season: data.season,
+    Rank: data.rank ?? 0,
+    "Leaderboard Share (%)": data.share ?? 0,
+    "Last Updated": data.last_update ?? "N/A",
+  }),
+  total: (data: RePointsResponse) => data.points,
+  rank: (data: RePointsResponse) => data.rank ?? 0,
+  supportedAddressTypes: ["evm"],
+} as AdapterExport;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [ ] Enable "Allow edits by maintainers" on this PR
- [ ] Test your adapter locally with a valid address/FID (EVM, SVM, or FID) and an invalid address/FID
- [ ] If EVM-supported, ensure your adapter works with different EVM address formats (checksummed, lowercase, uppercase)
- [ ] Do NOT edit/push `package.json` or any lockfile

---

### PR Type

- [ ] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update** - Fixing/improving an existing adapter
- [ ] **Bug Fix** - Fixing a specific issue
- [ ] **Other** (please describe)

---

### Testing Information

**Adapter File:** `adapters/your-adapter.ts`

**Test Address (with points):**

```
EVM address, SVM address, or FID integer...
```

**Expected Output:**

- Total Points:
- Rank:

**How to Test Locally:**

```bash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/your-adapter.ts <address-or-fid>
```

---

## Adapter Details

**Protocol Name:**

**Defillama Slug:**
(from [Defillama protocols API](https://api.llama.fi/protocols))

**Important Features:**

- [ ] Supports multiple address formats (lowercase, uppercase, checksummed)
- [ ] If SVM-supported, works with valid Solana base58 addresses
- [ ] CORS-friendly API calls
- [ ] Fails fast on errors
- [ ] Adapter result is 100% truth

---

**Notes:** (Any additional context for this PR)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added leaderboard and points tracking for Fairground, Ondo, and Re.
  * Displays project-specific point totals, rankings, breakdowns, and last-updated information.
  * Supports EVM wallet addresses for all three integrations.
  * Handles missing leaderboard or points data with appropriate default values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->