### PR TITLE
Add Dappster points adapter

### DIFF
--- a/adapters/dappster.ts
+++ b/adapters/dappster.ts
@@ -17,6 +17,41 @@ type DappsterResponse = {
   profileUrl: string | null;
 };
 
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isSafeInteger(value) && (value as number) >= 0;
+}
+
+function parseDappsterResponse(payload: unknown): DappsterResponse {
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    throw new Error("Dappster API returned a malformed points payload");
+  }
+
+  const value = payload as Record<string, unknown>;
+  const breakdown = value.breakdown;
+  const hasValidBreakdown = breakdown !== null &&
+    typeof breakdown === "object" &&
+    !Array.isArray(breakdown) &&
+    Object.entries(breakdown).every(([chain, points]) =>
+      chain.length > 0 && isNonNegativeInteger(points)
+    );
+
+  if (
+    value.protocol !== "Dappster" ||
+    typeof value.address !== "string" ||
+    (value.addressType !== "evm" && value.addressType !== "svm") ||
+    !isNonNegativeInteger(value.points) ||
+    !isNonNegativeInteger(value.rank) ||
+    !isNonNegativeInteger(value.publicApps) ||
+    !hasValidBreakdown ||
+    !(value.username === null || typeof value.username === "string") ||
+    !(value.profileUrl === null || typeof value.profileUrl === "string")
+  ) {
+    throw new Error("Dappster API returned a malformed points payload");
+  }
+
+  return value as DappsterResponse;
+}
+
 export default {
   fetch: async (address: string) => {
     const response = await fetch(
@@ -30,7 +65,8 @@ export default {
     if (!response.ok) {
       throw new Error(`Dappster API returned ${response.status}`);
     }
-    return await response.json() as DappsterResponse;
+    const payload: unknown = await response.json();
+    return parseDappsterResponse(payload);
   },
   data: (response: DappsterResponse) => ({
     "Dappster Points": response.points,

--- a/adapters/dappster.ts
+++ b/adapters/dappster.ts
@@ -1,0 +1,49 @@
+import type { AdapterExport } from "../utils/adapter.ts";
+import { maybeWrapCORSProxy } from "../utils/cors.ts";
+
+const API_URL = await maybeWrapCORSProxy(
+  "https://dappster.fun/api/public/points/{address}",
+);
+
+type DappsterResponse = {
+  protocol: "Dappster";
+  address: string;
+  addressType: "evm" | "svm";
+  points: number;
+  rank: number;
+  publicApps: number;
+  breakdown: Record<string, number>;
+  username: string | null;
+  profileUrl: string | null;
+};
+
+export default {
+  fetch: async (address: string) => {
+    const response = await fetch(
+      API_URL.replace("{address}", encodeURIComponent(address)),
+      {
+        headers: {
+          "User-Agent": "Checkpoint API (https://checkpoint.exchange)",
+        },
+      },
+    );
+    if (!response.ok) {
+      throw new Error(`Dappster API returned ${response.status}`);
+    }
+    return await response.json() as DappsterResponse;
+  },
+  data: (response: DappsterResponse) => ({
+    "Dappster Points": response.points,
+    "Public Marketplace dApps": response.publicApps,
+    "Creator": response.username || "Unclaimed public username",
+    ...Object.fromEntries(
+      Object.entries(response.breakdown).map(([chain, points]) => [
+        `${chain} dApps`,
+        points,
+      ]),
+    ),
+  }),
+  total: (response: DappsterResponse) => response.points,
+  rank: (response: DappsterResponse) => response.rank,
+  supportedAddressTypes: ["evm", "svm"],
+} as AdapterExport<DappsterResponse>;


### PR DESCRIPTION
## IMPORTANT NOTES

### Before Submitting:

- [x] Enable Allow edits by maintainers on this PR
- [x] Test the adapter locally with valid EVM/SVM addresses and an invalid address
- [x] Tested checksummed, lowercase, and uppercase EVM address formats
- [x] Did not edit package.json or any lockfile

---

### PR Type

- [x] **New Adapter** - Adding a new protocol adapter
- [ ] **Adapter Update**
- [ ] **Bug Fix**
- [ ] **Other**

---

### Testing Information

**Adapter File:** adapters/dappster.ts

**Test Addresses:**

`	ext
EVM: 0x5d69c42a3a481d0ccfd88cfa8a2a08e2bf456134
SVM: GxPoKNX26GCisuH8Sdr8rtfZY98L5t5eegKtDzSA9P6W
` 

**Expected Output at submission:**

- Total Points: 29
- Rank: 1

**How to Test Locally:**

`ash
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/dappster.ts 0x5d69c42a3a481d0ccfd88cfa8a2a08e2bf456134
deno run --allow-net --allow-read=adapters --allow-env test.ts adapters/dappster.ts GxPoKNX26GCisuH8Sdr8rtfZY98L5t5eegKtDzSA9P6W
` 

---

## Adapter Details

**Protocol Name:** Dappster

**Defillama Slug:** N/A — Dappster is a multichain dApp builder and Marketplace, not a DeFi protocol.

**Important Features:**

- [x] Supports lowercase, uppercase, and checksummed EVM addresses
- [x] Supports valid Solana base58 addresses
- [x] CORS-friendly API calls
- [x] Fails fast on errors
- [x] Adapter result is derived from current public deployments

---

**Notes:** One Dappster Point equals one unique dApp that is deployed onchain, published to IPFS, and currently public in the Dappster Marketplace. Linked EVM and Solana wallets resolve to one account total. Making a dApp private or deleting it removes the point; republishing restores it. Source API: https://dappster.fun/api/public/points/{address}.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for retrieving Dappster points and rankings.
  * Displays total points, rank, marketplace details, and chain-specific breakdowns.
  * Supports both EVM and SVM wallet addresses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->